### PR TITLE
[WIP] soc: Add clock() implementation

### DIFF
--- a/SoC/gd32vf103/Common/Source/Stubs/times.c
+++ b/SoC/gd32vf103/Common/Source/Stubs/times.c
@@ -1,0 +1,15 @@
+/* See LICENSE of license details. */
+
+#include <errno.h>
+#include <sys/times.h>
+#include "nuclei_sdk_soc.h"
+
+int _times(struct tms *buf)
+{
+    buf->tms_cstime = 0;
+    buf->tms_cutime = 0;
+    buf->tms_stime = __get_rv_cycle();
+    buf->tms_utime = 0;
+
+    return  0;
+}

--- a/SoC/gd32vf103/Common/Source/Stubs/times.c
+++ b/SoC/gd32vf103/Common/Source/Stubs/times.c
@@ -4,12 +4,12 @@
 #include <sys/times.h>
 #include "nuclei_sdk_soc.h"
 
-int _times(struct tms *buf)
+clock_t _times(struct tms *buf)
 {
     buf->tms_cstime = 0;
     buf->tms_cutime = 0;
     buf->tms_stime = __get_rv_cycle();
     buf->tms_utime = 0;
 
-    return  0;
+    return buf->tms_utime;
 }


### PR DESCRIPTION
Currently all calls to `clock()` return `-1`. This is default behavior when `_times()` is not implemented. 

https://github.com/riscv/riscv-newlib/blob/riscv-newlib-3.2.0/newlib/libc/time/clock.c

This PR implements the `_times()` stub by storing the `MCYCLE` register value as the  System CPU time. Based on newlib description below I assume this is correct.

_DESCRIPTION_
_Calculates the best available approximation of the cumulative amount of time used by your program since it started.  To convert the result into seconds, divide by the macro <<CLOCKS_PER_SEC>>._

_RETURNS_
_The amount of processor time used so far by your program, in units defined by the machine-dependent macro <<CLOCKS_PER_SEC>>.  If no measurement is available, the result is (clock_t)<<-1>>._

There still is the problem that currently `CLOCKS_PER_SEC` is defined as `1000000` which is wrong.

https://github.com/riscv/riscv-newlib/blob/riscv-newlib-3.2.0/newlib/libc/include/machine/time.h#L5

It should be `SystemCoreClock` ie `__SYSTEM_CLOCK_108M_PLL_HXTAL` ie `108000000` but I am not sure in what file it should be defined.