### PR TITLE
CI: Add github ci workflow for nuclei sdk

### DIFF
--- a/.github/workflows/build_sdk.yaml
+++ b/.github/workflows/build_sdk.yaml
@@ -11,6 +11,7 @@ on:
         - "test/**"
         - ".github/**"
         - ".ci/**"
+
   pull_request:
     paths:
         - "Build/**"
@@ -38,12 +39,12 @@ jobs:
         fetch-depth: 0
 
     - name: Caching tools
-        uses: actions/cache@v2
-        with:
-          path: |
-            prebuilt_tools/*.tar.bz2
-            *.zip
-          key: build
+      uses: actions/cache@v2
+      with:
+        path: |
+          prebuilt_tools/*.tar.bz2
+          prebuilt_tools/*.zip
+        key: build
 
     - name: Prepare Tools for Ubuntu
       if: startsWith(matrix.os, 'ubuntu')

--- a/.github/workflows/build_sdk.yaml
+++ b/.github/workflows/build_sdk.yaml
@@ -62,37 +62,51 @@ jobs:
     - name: Build SDK for HummingBird SoC
       if: matrix.soc == 'hbird'
       run: |
+        echo "Setup build environment"
         source setup.sh
         source .ci/build_sdk.sh
         source .ci/build_applications.sh
+        touch build.log
         export CORE=n305
         export DOWNLOAD=ilm
         echo "Build For Board hbird_eval, CORE=$CORE, DOWNLOAD=$DOWNLOAD"
-        SOC=hbird BOARD=hbird_eval nsdk_build_directory    application
-        SOC=hbird BOARD=hbird_eval nsdk_build_directory    test
+        SOC=hbird BOARD=hbird_eval nsdk_build_directory    application  >> build.log
+        SOC=hbird BOARD=hbird_eval nsdk_build_directory    test         >> build.log
         export CORE=ux600
         export DOWNLOAD=ddr
         echo "Build For Board hbird_eval, CORE=$CORE, DOWNLOAD=$DOWNLOAD"
-        SOC=hbird BOARD=hbird_eval nsdk_build_directory    application
-        SOC=hbird BOARD=hbird_eval nsdk_build_directory    test
+        SOC=hbird BOARD=hbird_eval nsdk_build_directory    application  >> build.log
+        SOC=hbird BOARD=hbird_eval nsdk_build_directory    test         >> build.log
         export CORE=n307fd
         export DOWNLOAD=flashxip
         echo "Build For Board hbird_eval, CORE=$CORE, DOWNLOAD=$DOWNLOAD"
-        SOC=hbird BOARD=hbird_eval nsdk_build_directory    application
-        SOC=hbird BOARD=hbird_eval nsdk_build_directory    test
+        SOC=hbird BOARD=hbird_eval nsdk_build_directory    application  >> build.log
+        SOC=hbird BOARD=hbird_eval nsdk_build_directory    test         >> build.log
+
+        mv build.log build_${{ matrix.soc }}.log
 
     - name: Build SDK for GD32VF103 SoC
       if: matrix.soc == 'gd32vf103'
       run: |
+        echo "Setup build environment"
         source setup.sh
         source .ci/build_sdk.sh
         source .ci/build_applications.sh
+        touch build.log
         export CORE=n205
         export DOWNLOAD=flashxip
         echo "Build For Board gd32vf103v_eval"
-        SOC=gd32vf103 BOARD=gd32vf103v_eval nsdk_build_directory    application
-        SOC=gd32vf103 BOARD=gd32vf103v_eval nsdk_build_directory    test
+        SOC=gd32vf103 BOARD=gd32vf103v_eval nsdk_build_directory    application >> build.log
+        SOC=gd32vf103 BOARD=gd32vf103v_eval nsdk_build_directory    test        >> build.log
         echo "Build For Board gd32vf103v_rvstar"
-        SOC=gd32vf103 BOARD=gd32vf103v_rvstar nsdk_build_directory    application
-        SOC=gd32vf103 BOARD=gd32vf103v_rvstar nsdk_build_directory    test
+        SOC=gd32vf103 BOARD=gd32vf103v_rvstar nsdk_build_directory    application   >> build.log
+        SOC=gd32vf103 BOARD=gd32vf103v_rvstar nsdk_build_directory    test          >> build.log
+        mv build.log build_${{ matrix.soc }}.log
+
+    - name: Upload Build Log for ${{ matrix.soc }}
+        uses: actions/upload-artifact@v2.2.0
+        with:
+          name: build_${{ matrix.soc }}
+          path: |
+            build*.log
 

--- a/.github/workflows/build_sdk.yaml
+++ b/.github/workflows/build_sdk.yaml
@@ -57,7 +57,7 @@ jobs:
           fi
           tar -xjf $toolzip
           cd ..
-          echo "NUCLEI_TOOL_ROOT=$(pwd)/prebuilt_tools" > ../setup_config.sh
+          echo "NUCLEI_TOOL_ROOT=$(pwd)/prebuilt_tools" > setup_config.sh
 
     - name: Build SDK for HummingBird SoC
       if: matrix.soc == 'hbird'

--- a/.github/workflows/build_sdk.yaml
+++ b/.github/workflows/build_sdk.yaml
@@ -1,0 +1,97 @@
+name: Build SDK
+
+on:
+  push:
+    paths:
+        - "Build/**"
+        - "application/**"
+        - "NMSIS/**"
+        - "OS/**"
+        - "SoC/**"
+        - "test/**"
+        - ".github/**"
+        - ".ci/**"
+  pull_request:
+    paths:
+        - "Build/**"
+        - "application/**"
+        - "NMSIS/**"
+        - "OS/**"
+        - "SoC/**"
+        - "test/**"
+        - ".github/**"
+        - ".ci/**"
+
+jobs:
+  build:
+    name: Build SDK
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-18.04]
+        soc: [hbird, gd32vf103]
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+        fetch-depth: 0
+
+    - name: Caching tools
+        uses: actions/cache@v2
+        with:
+          path: |
+            prebuilt_tools/*.tar.bz2
+            *.zip
+          key: build
+
+    - name: Prepare Tools for Ubuntu
+      if: startsWith(matrix.os, 'ubuntu')
+      run: |
+          mkdir -p prebuilt_tools
+          cd prebuilt_tools
+          toolzip=nuclei_riscv_newlibc_prebuilt_linux64_2020.08.tar.bz2
+          if [ ! -e $toolzip ] ; then
+            wget https://nucleisys.com/upload/files/toochain/gcc/$toolzip
+          fi
+          tar -xjf $toolzip
+          cd ..
+          echo "NUCLEI_TOOL_ROOT=$(pwd)/prebuilt_tools" > ../setup_config.sh
+
+    - name: Build SDK for HummingBird SoC
+      if: matrix.soc == 'hbird'
+      run: |
+        source setup.sh
+        source .ci/build_sdk.sh
+        source .ci/build_applications.sh
+        export CORE=n305
+        export DOWNLOAD=ilm
+        echo "Build For Board hbird_eval, CORE=$CORE, DOWNLOAD=$DOWNLOAD"
+        SOC=hbird BOARD=hbird_eval nsdk_build_directory    application
+        SOC=hbird BOARD=hbird_eval nsdk_build_directory    test
+        export CORE=ux600
+        export DOWNLOAD=ddr
+        echo "Build For Board hbird_eval, CORE=$CORE, DOWNLOAD=$DOWNLOAD"
+        SOC=hbird BOARD=hbird_eval nsdk_build_directory    application
+        SOC=hbird BOARD=hbird_eval nsdk_build_directory    test
+        export CORE=n307fd
+        export DOWNLOAD=flashxip
+        echo "Build For Board hbird_eval, CORE=$CORE, DOWNLOAD=$DOWNLOAD"
+        SOC=hbird BOARD=hbird_eval nsdk_build_directory    application
+        SOC=hbird BOARD=hbird_eval nsdk_build_directory    test
+
+    - name: Build SDK for GD32VF103 SoC
+      if: matrix.soc == 'gd32vf103'
+      run: |
+        source setup.sh
+        source .ci/build_sdk.sh
+        source .ci/build_applications.sh
+        export CORE=n205
+        export DOWNLOAD=flashxip
+        echo "Build For Board gd32vf103v_eval"
+        SOC=gd32vf103 BOARD=gd32vf103v_eval nsdk_build_directory    application
+        SOC=gd32vf103 BOARD=gd32vf103v_eval nsdk_build_directory    test
+        echo "Build For Board gd32vf103v_rvstar"
+        SOC=gd32vf103 BOARD=gd32vf103v_rvstar nsdk_build_directory    application
+        SOC=gd32vf103 BOARD=gd32vf103v_rvstar nsdk_build_directory    test
+

--- a/.github/workflows/build_sdk.yaml
+++ b/.github/workflows/build_sdk.yaml
@@ -104,9 +104,8 @@ jobs:
         mv build.log build_${{ matrix.soc }}.log
 
     - name: Upload Build Log for ${{ matrix.soc }}
-        uses: actions/upload-artifact@v2.2.0
-        with:
-          name: build_${{ matrix.soc }}
-          path: |
-            build*.log
-
+      uses: actions/upload-artifact@v2.2.0
+      with:
+        name: build_${{ matrix.soc }}
+        path: |
+          build*.log

--- a/.github/workflows/deploy_doc.yaml
+++ b/.github/workflows/deploy_doc.yaml
@@ -1,0 +1,55 @@
+name: Build Documentation
+
+on:
+  push:
+    paths:
+        - "doc/**"
+        - ".github/**"
+        - ".ci/**"
+  pull_request:
+    paths:
+        - "doc/**"
+        - ".github/**"
+        - ".ci/**"
+
+jobs:
+  build_deploy:
+    name: Build documentation
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-18.04]
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+        fetch-depth: 0
+    - name: Install Dependencies on Ubuntu
+      if: startsWith(matrix.os, 'ubuntu')
+      run: |
+          sudo apt-get install lftp python3 make latexmk \
+          texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended
+          sudo pip3 install -r doc/requirements.txt
+    - name: Build Documentation
+      run: |
+        cd doc
+        make all
+        make latexpdf
+        cp build/latex/*.pdf build/html/
+        cd ..
+    - name: Deploy Documentation
+      if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/master' }}
+      env:
+          FTPUSER: ${{ secrets.FTPUSER }}
+          FTPPWD: ${{ secrets.FTPPWD }}
+          FTPSERVER: ${{ secrets.FTPSERVER }}
+      run: |
+        bash .ci/ftp_deploy.sh $FTPUSER $FTPPWD $FTPSERVER doc/build/html nuclei_sdk
+    - name: Upload Documentation
+      uses: actions/upload-artifact@v2
+      with:
+        # Artifact name
+        name: nuclei_sdk_doc
+        # A file, directory or wildcard pattern that describes what to upload
+        path: doc/build/html


### PR DESCRIPTION
New github ci workflow for nuclei sdk, it supported:

* Use github workflow as ci flow
* It will build sphinx documentation and deploy it
* It will build nuclei sdk for different SoCs

This PR is used to fix issue #1 