### PR TITLE
soc: Replace TABs with spaces.

### DIFF
--- a/SoC/gd32vf103/Common/Include/gd32vf103_can.h
+++ b/SoC/gd32vf103/Common/Include/gd32vf103_can.h
@@ -329,117 +329,117 @@ OF SUCH DAMAGE.
 
 /* CAN flags */
 typedef enum {
-	/* flags in TSTAT register */
-	CAN_FLAG_MTE2 = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 19U), /*!< mailbox 2 transmit error */
-	CAN_FLAG_MTE1 = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 11U), /*!< mailbox 1 transmit error */
-	CAN_FLAG_MTE0 = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 3U), /*!< mailbox 0 transmit error */
-	CAN_FLAG_MTF2 = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 16U), /*!< mailbox 2 transmit finished */
-	CAN_FLAG_MTF1 = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 8U), /*!< mailbox 1 transmit finished */
-	CAN_FLAG_MTF0 = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 0U), /*!< mailbox 0 transmit finished */
-	/* flags in RFIFO0 register */
-	CAN_FLAG_RFO0 = CAN_REGIDX_BIT(RFIFO0_REG_OFFSET, 4U), /*!< receive FIFO0 overfull */
-	CAN_FLAG_RFF0 = CAN_REGIDX_BIT(RFIFO0_REG_OFFSET, 3U), /*!< receive FIFO0 full */
-	/* flags in RFIFO1 register */
-	CAN_FLAG_RFO1 = CAN_REGIDX_BIT(RFIFO1_REG_OFFSET, 4U), /*!< receive FIFO1 overfull */
-	CAN_FLAG_RFF1 = CAN_REGIDX_BIT(RFIFO1_REG_OFFSET, 3U), /*!< receive FIFO1 full */
-	/* flags in ERR register */
-	CAN_FLAG_BOERR = CAN_REGIDX_BIT(ERR_REG_OFFSET, 2U), /*!< bus-off error */
-	CAN_FLAG_PERR = CAN_REGIDX_BIT(ERR_REG_OFFSET, 1U), /*!< passive error */
-	CAN_FLAG_WERR = CAN_REGIDX_BIT(ERR_REG_OFFSET, 0U), /*!< warning error */
+    /* flags in TSTAT register */
+    CAN_FLAG_MTE2 = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 19U), /*!< mailbox 2 transmit error */
+    CAN_FLAG_MTE1 = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 11U), /*!< mailbox 1 transmit error */
+    CAN_FLAG_MTE0 = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 3U), /*!< mailbox 0 transmit error */
+    CAN_FLAG_MTF2 = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 16U), /*!< mailbox 2 transmit finished */
+    CAN_FLAG_MTF1 = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 8U), /*!< mailbox 1 transmit finished */
+    CAN_FLAG_MTF0 = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 0U), /*!< mailbox 0 transmit finished */
+    /* flags in RFIFO0 register */
+    CAN_FLAG_RFO0 = CAN_REGIDX_BIT(RFIFO0_REG_OFFSET, 4U), /*!< receive FIFO0 overfull */
+    CAN_FLAG_RFF0 = CAN_REGIDX_BIT(RFIFO0_REG_OFFSET, 3U), /*!< receive FIFO0 full */
+    /* flags in RFIFO1 register */
+    CAN_FLAG_RFO1 = CAN_REGIDX_BIT(RFIFO1_REG_OFFSET, 4U), /*!< receive FIFO1 overfull */
+    CAN_FLAG_RFF1 = CAN_REGIDX_BIT(RFIFO1_REG_OFFSET, 3U), /*!< receive FIFO1 full */
+    /* flags in ERR register */
+    CAN_FLAG_BOERR = CAN_REGIDX_BIT(ERR_REG_OFFSET, 2U), /*!< bus-off error */
+    CAN_FLAG_PERR = CAN_REGIDX_BIT(ERR_REG_OFFSET, 1U), /*!< passive error */
+    CAN_FLAG_WERR = CAN_REGIDX_BIT(ERR_REG_OFFSET, 0U), /*!< warning error */
 } can_flag_enum;
 
 /* CAN interrupt flags */
 typedef enum {
-	/* interrupt flags in STAT register */
-	CAN_INT_FLAG_SLPIF = CAN_REGIDX_BITS(STAT_REG_OFFSET, 4U, 17U), /*!< status change interrupt flag of sleep working mode entering */
-	CAN_INT_FLAG_WUIF = CAN_REGIDX_BITS(STAT_REG_OFFSET, 3U, 16), /*!< status change interrupt flag of wakeup from sleep working mode */
-	CAN_INT_FLAG_ERRIF = CAN_REGIDX_BITS(STAT_REG_OFFSET, 2U, 15), /*!< error interrupt flag */
-	/* interrupt flags in TSTAT register */
-	CAN_INT_FLAG_MTF2 = CAN_REGIDX_BITS(TSTAT_REG_OFFSET, 16U, 0U), /*!< mailbox 2 transmit finished interrupt flag */
-	CAN_INT_FLAG_MTF1 = CAN_REGIDX_BITS(TSTAT_REG_OFFSET, 8U, 0U), /*!< mailbox 1 transmit finished interrupt flag */
-	CAN_INT_FLAG_MTF0 = CAN_REGIDX_BITS(TSTAT_REG_OFFSET, 0U, 0U), /*!< mailbox 0 transmit finished interrupt flag */
-	/* interrupt flags in RFIFO0 register */
-	CAN_INT_FLAG_RFO0 = CAN_REGIDX_BITS(RFIFO0_REG_OFFSET, 4U, 3U), /*!< receive FIFO0 overfull interrupt flag */
-	CAN_INT_FLAG_RFF0 = CAN_REGIDX_BITS(RFIFO0_REG_OFFSET, 3U, 2U), /*!< receive FIFO0 full interrupt flag */
-	/* interrupt flags in RFIFO0 register */
-	CAN_INT_FLAG_RFO1 = CAN_REGIDX_BITS(RFIFO1_REG_OFFSET, 4U, 6U), /*!< receive FIFO1 overfull interrupt flag */
-	CAN_INT_FLAG_RFF1 = CAN_REGIDX_BITS(RFIFO1_REG_OFFSET, 3U, 5U), /*!< receive FIFO1 full interrupt flag */
+    /* interrupt flags in STAT register */
+    CAN_INT_FLAG_SLPIF = CAN_REGIDX_BITS(STAT_REG_OFFSET, 4U, 17U), /*!< status change interrupt flag of sleep working mode entering */
+    CAN_INT_FLAG_WUIF = CAN_REGIDX_BITS(STAT_REG_OFFSET, 3U, 16), /*!< status change interrupt flag of wakeup from sleep working mode */
+    CAN_INT_FLAG_ERRIF = CAN_REGIDX_BITS(STAT_REG_OFFSET, 2U, 15), /*!< error interrupt flag */
+    /* interrupt flags in TSTAT register */
+    CAN_INT_FLAG_MTF2 = CAN_REGIDX_BITS(TSTAT_REG_OFFSET, 16U, 0U), /*!< mailbox 2 transmit finished interrupt flag */
+    CAN_INT_FLAG_MTF1 = CAN_REGIDX_BITS(TSTAT_REG_OFFSET, 8U, 0U), /*!< mailbox 1 transmit finished interrupt flag */
+    CAN_INT_FLAG_MTF0 = CAN_REGIDX_BITS(TSTAT_REG_OFFSET, 0U, 0U), /*!< mailbox 0 transmit finished interrupt flag */
+    /* interrupt flags in RFIFO0 register */
+    CAN_INT_FLAG_RFO0 = CAN_REGIDX_BITS(RFIFO0_REG_OFFSET, 4U, 3U), /*!< receive FIFO0 overfull interrupt flag */
+    CAN_INT_FLAG_RFF0 = CAN_REGIDX_BITS(RFIFO0_REG_OFFSET, 3U, 2U), /*!< receive FIFO0 full interrupt flag */
+    /* interrupt flags in RFIFO0 register */
+    CAN_INT_FLAG_RFO1 = CAN_REGIDX_BITS(RFIFO1_REG_OFFSET, 4U, 6U), /*!< receive FIFO1 overfull interrupt flag */
+    CAN_INT_FLAG_RFF1 = CAN_REGIDX_BITS(RFIFO1_REG_OFFSET, 3U, 5U), /*!< receive FIFO1 full interrupt flag */
 } can_interrupt_flag_enum;
 
 /* CAN initiliaze parameters struct */
 typedef struct {
-	uint8_t working_mode; /*!< CAN working mode */
-	uint8_t resync_jump_width; /*!< CAN resynchronization jump width */
-	uint8_t time_segment_1; /*!< time segment 1 */
-	uint8_t time_segment_2; /*!< time segment 2 */
-	ControlStatus time_triggered; /*!< time triggered communication mode */
-	ControlStatus auto_bus_off_recovery; /*!< automatic bus-off recovery */
-	ControlStatus auto_wake_up; /*!< automatic wake-up mode */
-	ControlStatus no_auto_retrans; /*!< automatic retransmission mode disable */
-	ControlStatus rec_fifo_overwrite; /*!< receive FIFO overwrite mode */
-	ControlStatus trans_fifo_order; /*!< transmit FIFO order */
-	uint16_t prescaler; /*!< baudrate prescaler */
+    uint8_t working_mode; /*!< CAN working mode */
+    uint8_t resync_jump_width; /*!< CAN resynchronization jump width */
+    uint8_t time_segment_1; /*!< time segment 1 */
+    uint8_t time_segment_2; /*!< time segment 2 */
+    ControlStatus time_triggered; /*!< time triggered communication mode */
+    ControlStatus auto_bus_off_recovery; /*!< automatic bus-off recovery */
+    ControlStatus auto_wake_up; /*!< automatic wake-up mode */
+    ControlStatus no_auto_retrans; /*!< automatic retransmission mode disable */
+    ControlStatus rec_fifo_overwrite; /*!< receive FIFO overwrite mode */
+    ControlStatus trans_fifo_order; /*!< transmit FIFO order */
+    uint16_t prescaler; /*!< baudrate prescaler */
 } can_parameter_struct;
 
 /* CAN transmit message struct */
 typedef struct {
-	uint32_t tx_sfid; /*!< standard format frame identifier */
-	uint32_t tx_efid; /*!< extended format frame identifier */
-	uint8_t tx_ff; /*!< format of frame, standard or extended format */
-	uint8_t tx_ft; /*!< type of frame, data or remote */
-	uint8_t tx_dlen; /*!< data length */
-	uint8_t tx_data[8]; /*!< transmit data */
+    uint32_t tx_sfid; /*!< standard format frame identifier */
+    uint32_t tx_efid; /*!< extended format frame identifier */
+    uint8_t tx_ff; /*!< format of frame, standard or extended format */
+    uint8_t tx_ft; /*!< type of frame, data or remote */
+    uint8_t tx_dlen; /*!< data length */
+    uint8_t tx_data[8]; /*!< transmit data */
 } can_trasnmit_message_struct;
 
 /* CAN receive message struct */
 typedef struct {
-	uint32_t rx_sfid; /*!< standard format frame identifier */
-	uint32_t rx_efid; /*!< extended format frame identifier */
-	uint8_t rx_ff; /*!< format of frame, standard or extended format */
-	uint8_t rx_ft; /*!< type of frame, data or remote */
-	uint8_t rx_dlen; /*!< data length */
-	uint8_t rx_data[8]; /*!< receive data */
-	uint8_t rx_fi; /*!< filtering index */
+    uint32_t rx_sfid; /*!< standard format frame identifier */
+    uint32_t rx_efid; /*!< extended format frame identifier */
+    uint8_t rx_ff; /*!< format of frame, standard or extended format */
+    uint8_t rx_ft; /*!< type of frame, data or remote */
+    uint8_t rx_dlen; /*!< data length */
+    uint8_t rx_data[8]; /*!< receive data */
+    uint8_t rx_fi; /*!< filtering index */
 } can_receive_message_struct;
 
 /* CAN filter parameters struct */
 typedef struct {
-	uint16_t filter_list_high; /*!< filter list number high bits*/
-	uint16_t filter_list_low; /*!< filter list number low bits */
-	uint16_t filter_mask_high; /*!< filter mask number high bits */
-	uint16_t filter_mask_low; /*!< filter mask number low bits */
-	uint16_t filter_fifo_number; /*!< receive FIFO associated with the filter */
-	uint16_t filter_number; /*!< filter number */
-	uint16_t filter_mode; /*!< filter mode, list or mask */
-	uint16_t filter_bits; /*!< filter scale */
-	ControlStatus filter_enable; /*!< filter work or not */
+    uint16_t filter_list_high; /*!< filter list number high bits*/
+    uint16_t filter_list_low; /*!< filter list number low bits */
+    uint16_t filter_mask_high; /*!< filter mask number high bits */
+    uint16_t filter_mask_low; /*!< filter mask number low bits */
+    uint16_t filter_fifo_number; /*!< receive FIFO associated with the filter */
+    uint16_t filter_number; /*!< filter number */
+    uint16_t filter_mode; /*!< filter mode, list or mask */
+    uint16_t filter_bits; /*!< filter scale */
+    ControlStatus filter_enable; /*!< filter work or not */
 } can_filter_parameter_struct;
 
 /* CAN errors */
 typedef enum {
-	CAN_ERROR_NONE = 0, /*!< no error */
-	CAN_ERROR_FILL, /*!< fill error */
-	CAN_ERROR_FORMATE, /*!< format error */
-	CAN_ERROR_ACK, /*!< ACK error */
-	CAN_ERROR_BITRECESSIVE, /*!< bit recessive error */
-	CAN_ERROR_BITDOMINANTER, /*!< bit dominant error */
-	CAN_ERROR_CRC, /*!< CRC error */
-	CAN_ERROR_SOFTWARECFG, /*!< software configure */
+    CAN_ERROR_NONE = 0, /*!< no error */
+    CAN_ERROR_FILL, /*!< fill error */
+    CAN_ERROR_FORMATE, /*!< format error */
+    CAN_ERROR_ACK, /*!< ACK error */
+    CAN_ERROR_BITRECESSIVE, /*!< bit recessive error */
+    CAN_ERROR_BITDOMINANTER, /*!< bit dominant error */
+    CAN_ERROR_CRC, /*!< CRC error */
+    CAN_ERROR_SOFTWARECFG, /*!< software configure */
 } can_error_enum;
 
 /* transmit states */
 typedef enum {
-	CAN_TRANSMIT_FAILED = 0, /*!< CAN transmitted failure */
-	CAN_TRANSMIT_OK = 1, /*!< CAN transmitted success */
-	CAN_TRANSMIT_PENDING = 2, /*!< CAN transmitted pending */
-	CAN_TRANSMIT_NOMAILBOX = 4, /*!< no empty mailbox to be used for CAN */
+    CAN_TRANSMIT_FAILED = 0, /*!< CAN transmitted failure */
+    CAN_TRANSMIT_OK = 1, /*!< CAN transmitted success */
+    CAN_TRANSMIT_PENDING = 2, /*!< CAN transmitted pending */
+    CAN_TRANSMIT_NOMAILBOX = 4, /*!< no empty mailbox to be used for CAN */
 } can_transmit_state_enum;
 
 typedef enum {
-	CAN_INIT_STRUCT = 0, /* CAN initiliaze parameters struct */
-	CAN_FILTER_STRUCT, /* CAN filter parameters struct */
-	CAN_TX_MESSAGE_STRUCT, /* CAN transmit message struct */
-	CAN_RX_MESSAGE_STRUCT, /* CAN receive message struct */
+    CAN_INIT_STRUCT = 0, /* CAN initiliaze parameters struct */
+    CAN_FILTER_STRUCT, /* CAN filter parameters struct */
+    CAN_TX_MESSAGE_STRUCT, /* CAN transmit message struct */
+    CAN_RX_MESSAGE_STRUCT, /* CAN receive message struct */
 } can_struct_type_enum;
 
 /* CAN baudrate prescaler*/
@@ -660,7 +660,7 @@ void can_deinit(uint32_t can_periph);
 void can_struct_para_init(can_struct_type_enum type, void* p_struct);
 /* initialize CAN */
 ErrStatus can_init(uint32_t can_periph,
-		can_parameter_struct* can_parameter_init);
+        can_parameter_struct* can_parameter_init);
 /* CAN filter init */
 void can_filter_init(can_filter_parameter_struct* can_filter_parameter_init);
 /* set can1 fliter start bank number */
@@ -678,15 +678,15 @@ void can_time_trigger_mode_disable(uint32_t can_periph);
 /* transmit functions */
 /* transmit CAN message */
 uint8_t can_message_transmit(uint32_t can_periph,
-		can_trasnmit_message_struct* transmit_message);
+        can_trasnmit_message_struct* transmit_message);
 /* get CAN transmit state */
 can_transmit_state_enum can_transmit_states(uint32_t can_periph,
-		uint8_t mailbox_number);
+        uint8_t mailbox_number);
 /* stop CAN transmission */
 void can_transmission_stop(uint32_t can_periph, uint8_t mailbox_number);
 /* CAN receive message */
 void can_message_receive(uint32_t can_periph, uint8_t fifo_number,
-		can_receive_message_struct* receive_message);
+        can_receive_message_struct* receive_message);
 /* CAN release fifo */
 void can_fifo_release(uint32_t can_periph, uint8_t fifo_number);
 /* CAN receive message length */
@@ -713,7 +713,7 @@ FlagStatus can_flag_get(uint32_t can_periph, can_flag_enum flag);
 void can_flag_clear(uint32_t can_periph, can_flag_enum flag);
 /* CAN get interrupt flag state */
 FlagStatus can_interrupt_flag_get(uint32_t can_periph,
-		can_interrupt_flag_enum flag);
+        can_interrupt_flag_enum flag);
 /* CAN clear interrupt flag state */
 void can_interrupt_flag_clear(uint32_t can_periph, can_interrupt_flag_enum flag);
 

--- a/SoC/gd32vf103/Common/Include/gd32vf103_dma.h
+++ b/SoC/gd32vf103/Common/Include/gd32vf103_dma.h
@@ -183,8 +183,8 @@ typedef struct
 #define DMA_INT_ERR                         DMA_CHXCTL_ERRIE                                /*!< enable bit for channel error interrupt */
 
 /* transfer direction */
-#define DMA_PERIPHERAL_TO_MEMORY            ((uint8_t)0x0000U)                         		/*!< read from peripheral and write to memory */
-#define DMA_MEMORY_TO_PERIPHERAL            ((uint8_t)0x0001U)                         		/*!< read from memory and write to peripheral */
+#define DMA_PERIPHERAL_TO_MEMORY            ((uint8_t)0x0000U)                                 /*!< read from peripheral and write to memory */
+#define DMA_MEMORY_TO_PERIPHERAL            ((uint8_t)0x0001U)                                 /*!< read from memory and write to peripheral */
 
 /* peripheral increasing mode */
 #define DMA_PERIPH_INCREASE_DISABLE         ((uint8_t)0x0000U)                              /*!< next address of peripheral is fixed address mode */

--- a/SoC/gd32vf103/Common/Include/gd32vf103_rcu.h
+++ b/SoC/gd32vf103/Common/Include/gd32vf103_rcu.h
@@ -299,146 +299,146 @@ OF SUCH DAMAGE.
 
 /* peripheral clock enable */
 typedef enum {
-	/* AHB peripherals */
-	RCU_DMA0 = RCU_REGIDX_BIT(AHBEN_REG_OFFSET, 0U),              /*!< DMA0 clock */
-	RCU_DMA1 = RCU_REGIDX_BIT(AHBEN_REG_OFFSET, 1U),              /*!< DMA1 clock */
-	RCU_CRC = RCU_REGIDX_BIT(AHBEN_REG_OFFSET, 6U),               /*!< CRC clock */
-	RCU_EXMC = RCU_REGIDX_BIT(AHBEN_REG_OFFSET, 8U),              /*!< EXMC clock */
-	RCU_USBFS = RCU_REGIDX_BIT(AHBEN_REG_OFFSET, 12U),            /*!< USBFS clock */
-	/* APB1 peripherals */
-	RCU_TIMER1 = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 0U),           /*!< TIMER1 clock */
-	RCU_TIMER2 = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 1U),           /*!< TIMER2 clock */
-	RCU_TIMER3 = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 2U),           /*!< TIMER3 clock */
-	RCU_TIMER4 = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 3U),           /*!< TIMER4 clock */
-	RCU_TIMER5 = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 4U),           /*!< TIMER5 clock */
-	RCU_TIMER6 = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 5U),           /*!< TIMER6 clock */
-	RCU_WWDGT = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 11U),           /*!< WWDGT clock */
-	RCU_SPI1 = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 14U),            /*!< SPI1 clock */
-	RCU_SPI2 = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 15U),            /*!< SPI2 clock */
-	RCU_USART1 = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 17U),          /*!< USART1 clock */
-	RCU_USART2 = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 18U),          /*!< USART2 clock */
-	RCU_UART3 = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 19U),           /*!< UART3 clock */
-	RCU_UART4 = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 20U),           /*!< UART4 clock */
-	RCU_I2C0 = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 21U),            /*!< I2C0 clock */
-	RCU_I2C1 = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 22U),            /*!< I2C1 clock */
-	RCU_CAN0 = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 25U),            /*!< CAN0 clock */
-	RCU_CAN1 = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 26U),            /*!< CAN1 clock */
-	RCU_BKPI = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 27U),            /*!< BKPI clock */
-	RCU_PMU = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 28U),             /*!< PMU clock */
-	RCU_DAC = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 29U),             /*!< DAC clock */
-	RCU_RTC = RCU_REGIDX_BIT(BDCTL_REG_OFFSET, 15U),              /*!< RTC clock */
-	/* APB2 peripherals */
-	RCU_AF = RCU_REGIDX_BIT(APB2EN_REG_OFFSET, 0U),               /*!< alternate function clock */
-	RCU_GPIOA = RCU_REGIDX_BIT(APB2EN_REG_OFFSET, 2U),            /*!< GPIOA clock */
-	RCU_GPIOB = RCU_REGIDX_BIT(APB2EN_REG_OFFSET, 3U),            /*!< GPIOB clock */
-	RCU_GPIOC = RCU_REGIDX_BIT(APB2EN_REG_OFFSET, 4U),            /*!< GPIOC clock */
-	RCU_GPIOD = RCU_REGIDX_BIT(APB2EN_REG_OFFSET, 5U),            /*!< GPIOD clock */
-	RCU_GPIOE = RCU_REGIDX_BIT(APB2EN_REG_OFFSET, 6U),            /*!< GPIOE clock */
-	RCU_ADC0 = RCU_REGIDX_BIT(APB2EN_REG_OFFSET, 9U),             /*!< ADC0 clock */
-	RCU_ADC1 = RCU_REGIDX_BIT(APB2EN_REG_OFFSET, 10U),            /*!< ADC1 clock */
-	RCU_TIMER0 = RCU_REGIDX_BIT(APB2EN_REG_OFFSET, 11U),          /*!< TIMER0 clock */
-	RCU_SPI0 = RCU_REGIDX_BIT(APB2EN_REG_OFFSET, 12U),            /*!< SPI0 clock */
-	RCU_USART0 = RCU_REGIDX_BIT(APB2EN_REG_OFFSET, 14U),          /*!< USART0 clock */
+    /* AHB peripherals */
+    RCU_DMA0 = RCU_REGIDX_BIT(AHBEN_REG_OFFSET, 0U),              /*!< DMA0 clock */
+    RCU_DMA1 = RCU_REGIDX_BIT(AHBEN_REG_OFFSET, 1U),              /*!< DMA1 clock */
+    RCU_CRC = RCU_REGIDX_BIT(AHBEN_REG_OFFSET, 6U),               /*!< CRC clock */
+    RCU_EXMC = RCU_REGIDX_BIT(AHBEN_REG_OFFSET, 8U),              /*!< EXMC clock */
+    RCU_USBFS = RCU_REGIDX_BIT(AHBEN_REG_OFFSET, 12U),            /*!< USBFS clock */
+    /* APB1 peripherals */
+    RCU_TIMER1 = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 0U),           /*!< TIMER1 clock */
+    RCU_TIMER2 = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 1U),           /*!< TIMER2 clock */
+    RCU_TIMER3 = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 2U),           /*!< TIMER3 clock */
+    RCU_TIMER4 = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 3U),           /*!< TIMER4 clock */
+    RCU_TIMER5 = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 4U),           /*!< TIMER5 clock */
+    RCU_TIMER6 = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 5U),           /*!< TIMER6 clock */
+    RCU_WWDGT = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 11U),           /*!< WWDGT clock */
+    RCU_SPI1 = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 14U),            /*!< SPI1 clock */
+    RCU_SPI2 = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 15U),            /*!< SPI2 clock */
+    RCU_USART1 = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 17U),          /*!< USART1 clock */
+    RCU_USART2 = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 18U),          /*!< USART2 clock */
+    RCU_UART3 = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 19U),           /*!< UART3 clock */
+    RCU_UART4 = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 20U),           /*!< UART4 clock */
+    RCU_I2C0 = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 21U),            /*!< I2C0 clock */
+    RCU_I2C1 = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 22U),            /*!< I2C1 clock */
+    RCU_CAN0 = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 25U),            /*!< CAN0 clock */
+    RCU_CAN1 = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 26U),            /*!< CAN1 clock */
+    RCU_BKPI = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 27U),            /*!< BKPI clock */
+    RCU_PMU = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 28U),             /*!< PMU clock */
+    RCU_DAC = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 29U),             /*!< DAC clock */
+    RCU_RTC = RCU_REGIDX_BIT(BDCTL_REG_OFFSET, 15U),              /*!< RTC clock */
+    /* APB2 peripherals */
+    RCU_AF = RCU_REGIDX_BIT(APB2EN_REG_OFFSET, 0U),               /*!< alternate function clock */
+    RCU_GPIOA = RCU_REGIDX_BIT(APB2EN_REG_OFFSET, 2U),            /*!< GPIOA clock */
+    RCU_GPIOB = RCU_REGIDX_BIT(APB2EN_REG_OFFSET, 3U),            /*!< GPIOB clock */
+    RCU_GPIOC = RCU_REGIDX_BIT(APB2EN_REG_OFFSET, 4U),            /*!< GPIOC clock */
+    RCU_GPIOD = RCU_REGIDX_BIT(APB2EN_REG_OFFSET, 5U),            /*!< GPIOD clock */
+    RCU_GPIOE = RCU_REGIDX_BIT(APB2EN_REG_OFFSET, 6U),            /*!< GPIOE clock */
+    RCU_ADC0 = RCU_REGIDX_BIT(APB2EN_REG_OFFSET, 9U),             /*!< ADC0 clock */
+    RCU_ADC1 = RCU_REGIDX_BIT(APB2EN_REG_OFFSET, 10U),            /*!< ADC1 clock */
+    RCU_TIMER0 = RCU_REGIDX_BIT(APB2EN_REG_OFFSET, 11U),          /*!< TIMER0 clock */
+    RCU_SPI0 = RCU_REGIDX_BIT(APB2EN_REG_OFFSET, 12U),            /*!< SPI0 clock */
+    RCU_USART0 = RCU_REGIDX_BIT(APB2EN_REG_OFFSET, 14U),          /*!< USART0 clock */
 } rcu_periph_enum;
 
 /* peripheral clock enable when sleep mode*/
 typedef enum {
 /* AHB peripherals */
-	RCU_SRAM_SLP = RCU_REGIDX_BIT(AHBEN_REG_OFFSET, 2U),          /*!< SRAM clock */
-	RCU_FMC_SLP = RCU_REGIDX_BIT(AHBEN_REG_OFFSET, 4U),           /*!< FMC clock */
+    RCU_SRAM_SLP = RCU_REGIDX_BIT(AHBEN_REG_OFFSET, 2U),          /*!< SRAM clock */
+    RCU_FMC_SLP = RCU_REGIDX_BIT(AHBEN_REG_OFFSET, 4U),           /*!< FMC clock */
 } rcu_periph_sleep_enum;
 
 /* peripherals reset */
 typedef enum {
-	/* AHB peripherals */
-	RCU_USBFSRST = RCU_REGIDX_BIT(AHBRST_REG_OFFSET, 12U),        /*!< USBFS clock reset */
-	/* APB1 peripherals */
-	RCU_TIMER1RST = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 0U),       /*!< TIMER1 clock reset */
-	RCU_TIMER2RST = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 1U),       /*!< TIMER2 clock reset */
-	RCU_TIMER3RST = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 2U),       /*!< TIMER3 clock reset */
-	RCU_TIMER4RST = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 3U),       /*!< TIMER4 clock reset */
-	RCU_TIMER5RST = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 4U),       /*!< TIMER5 clock reset */
-	RCU_TIMER6RST = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 5U),       /*!< TIMER6 clock reset */
-	RCU_WWDGTRST = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 11U),       /*!< WWDGT clock reset */
-	RCU_SPI1RST = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 14U),        /*!< SPI1 clock reset */
-	RCU_SPI2RST = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 15U),        /*!< SPI2 clock reset */
-	RCU_USART1RST = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 17U),      /*!< USART1 clock reset */
-	RCU_USART2RST = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 18U),      /*!< USART2 clock reset */
-	RCU_UART3RST = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 19U),       /*!< UART3 clock reset */
-	RCU_UART4RST = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 20U),       /*!< UART4 clock reset */
-	RCU_I2C0RST = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 21U),        /*!< I2C0 clock reset */
-	RCU_I2C1RST = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 22U),        /*!< I2C1 clock reset */
-	RCU_CAN0RST = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 25U),        /*!< CAN0 clock reset */
-	RCU_CAN1RST = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 26U),        /*!< CAN1 clock reset */
-	RCU_BKPIRST = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 27U),        /*!< BKPI clock reset */
-	RCU_PMURST = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 28U),         /*!< PMU clock reset */
-	RCU_DACRST = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 29U),         /*!< DAC clock reset */
-	/* APB2 peripherals */
-	RCU_AFRST = RCU_REGIDX_BIT(APB2RST_REG_OFFSET, 0U),           /*!< alternate function clock reset */
-	RCU_GPIOARST = RCU_REGIDX_BIT(APB2RST_REG_OFFSET, 2U),        /*!< GPIOA clock reset */
-	RCU_GPIOBRST = RCU_REGIDX_BIT(APB2RST_REG_OFFSET, 3U),        /*!< GPIOB clock reset */
-	RCU_GPIOCRST = RCU_REGIDX_BIT(APB2RST_REG_OFFSET, 4U),        /*!< GPIOC clock reset */
-	RCU_GPIODRST = RCU_REGIDX_BIT(APB2RST_REG_OFFSET, 5U),        /*!< GPIOD clock reset */
-	RCU_GPIOERST = RCU_REGIDX_BIT(APB2RST_REG_OFFSET, 6U),        /*!< GPIOE clock reset */
-	RCU_ADC0RST = RCU_REGIDX_BIT(APB2RST_REG_OFFSET, 9U),         /*!< ADC0 clock reset */
-	RCU_ADC1RST = RCU_REGIDX_BIT(APB2RST_REG_OFFSET, 10U),        /*!< ADC1 clock reset */
-	RCU_TIMER0RST = RCU_REGIDX_BIT(APB2RST_REG_OFFSET, 11U),      /*!< TIMER0 clock reset */
-	RCU_SPI0RST = RCU_REGIDX_BIT(APB2RST_REG_OFFSET, 12U),        /*!< SPI0 clock reset */
-	RCU_USART0RST = RCU_REGIDX_BIT(APB2RST_REG_OFFSET, 14U),      /*!< USART0 clock reset */
+    /* AHB peripherals */
+    RCU_USBFSRST = RCU_REGIDX_BIT(AHBRST_REG_OFFSET, 12U),        /*!< USBFS clock reset */
+    /* APB1 peripherals */
+    RCU_TIMER1RST = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 0U),       /*!< TIMER1 clock reset */
+    RCU_TIMER2RST = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 1U),       /*!< TIMER2 clock reset */
+    RCU_TIMER3RST = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 2U),       /*!< TIMER3 clock reset */
+    RCU_TIMER4RST = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 3U),       /*!< TIMER4 clock reset */
+    RCU_TIMER5RST = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 4U),       /*!< TIMER5 clock reset */
+    RCU_TIMER6RST = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 5U),       /*!< TIMER6 clock reset */
+    RCU_WWDGTRST = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 11U),       /*!< WWDGT clock reset */
+    RCU_SPI1RST = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 14U),        /*!< SPI1 clock reset */
+    RCU_SPI2RST = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 15U),        /*!< SPI2 clock reset */
+    RCU_USART1RST = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 17U),      /*!< USART1 clock reset */
+    RCU_USART2RST = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 18U),      /*!< USART2 clock reset */
+    RCU_UART3RST = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 19U),       /*!< UART3 clock reset */
+    RCU_UART4RST = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 20U),       /*!< UART4 clock reset */
+    RCU_I2C0RST = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 21U),        /*!< I2C0 clock reset */
+    RCU_I2C1RST = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 22U),        /*!< I2C1 clock reset */
+    RCU_CAN0RST = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 25U),        /*!< CAN0 clock reset */
+    RCU_CAN1RST = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 26U),        /*!< CAN1 clock reset */
+    RCU_BKPIRST = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 27U),        /*!< BKPI clock reset */
+    RCU_PMURST = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 28U),         /*!< PMU clock reset */
+    RCU_DACRST = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 29U),         /*!< DAC clock reset */
+    /* APB2 peripherals */
+    RCU_AFRST = RCU_REGIDX_BIT(APB2RST_REG_OFFSET, 0U),           /*!< alternate function clock reset */
+    RCU_GPIOARST = RCU_REGIDX_BIT(APB2RST_REG_OFFSET, 2U),        /*!< GPIOA clock reset */
+    RCU_GPIOBRST = RCU_REGIDX_BIT(APB2RST_REG_OFFSET, 3U),        /*!< GPIOB clock reset */
+    RCU_GPIOCRST = RCU_REGIDX_BIT(APB2RST_REG_OFFSET, 4U),        /*!< GPIOC clock reset */
+    RCU_GPIODRST = RCU_REGIDX_BIT(APB2RST_REG_OFFSET, 5U),        /*!< GPIOD clock reset */
+    RCU_GPIOERST = RCU_REGIDX_BIT(APB2RST_REG_OFFSET, 6U),        /*!< GPIOE clock reset */
+    RCU_ADC0RST = RCU_REGIDX_BIT(APB2RST_REG_OFFSET, 9U),         /*!< ADC0 clock reset */
+    RCU_ADC1RST = RCU_REGIDX_BIT(APB2RST_REG_OFFSET, 10U),        /*!< ADC1 clock reset */
+    RCU_TIMER0RST = RCU_REGIDX_BIT(APB2RST_REG_OFFSET, 11U),      /*!< TIMER0 clock reset */
+    RCU_SPI0RST = RCU_REGIDX_BIT(APB2RST_REG_OFFSET, 12U),        /*!< SPI0 clock reset */
+    RCU_USART0RST = RCU_REGIDX_BIT(APB2RST_REG_OFFSET, 14U),      /*!< USART0 clock reset */
 } rcu_periph_reset_enum;
 
 /* clock stabilization and peripheral reset flags */
 typedef enum {
-	/* clock stabilization flags */
-	RCU_FLAG_IRC8MSTB = RCU_REGIDX_BIT(CTL_REG_OFFSET, 1U),       /*!< IRC8M stabilization flags */
-	RCU_FLAG_HXTALSTB = RCU_REGIDX_BIT(CTL_REG_OFFSET, 17U),      /*!< HXTAL stabilization flags */
-	RCU_FLAG_PLLSTB = RCU_REGIDX_BIT(CTL_REG_OFFSET, 25U),        /*!< PLL stabilization flags */
-	RCU_FLAG_PLL1STB = RCU_REGIDX_BIT(CTL_REG_OFFSET, 27U),       /*!< PLL1 stabilization flags */
-	RCU_FLAG_PLL2STB = RCU_REGIDX_BIT(CTL_REG_OFFSET, 29U),       /*!< PLL2 stabilization flags */
-	RCU_FLAG_LXTALSTB = RCU_REGIDX_BIT(BDCTL_REG_OFFSET, 1U),     /*!< LXTAL stabilization flags */
-	RCU_FLAG_IRC40KSTB = RCU_REGIDX_BIT(RSTSCK_REG_OFFSET, 1U),   /*!< IRC40K stabilization flags */
-	/* reset source flags */
-	RCU_FLAG_EPRST = RCU_REGIDX_BIT(RSTSCK_REG_OFFSET, 26U),      /*!< external PIN reset flags */
-	RCU_FLAG_PORRST = RCU_REGIDX_BIT(RSTSCK_REG_OFFSET, 27U),     /*!< power reset flags */
-	RCU_FLAG_SWRST = RCU_REGIDX_BIT(RSTSCK_REG_OFFSET, 28U),      /*!< software reset flags */
-	RCU_FLAG_FWDGTRST = RCU_REGIDX_BIT(RSTSCK_REG_OFFSET, 29U),   /*!< FWDGT reset flags */
-	RCU_FLAG_WWDGTRST = RCU_REGIDX_BIT(RSTSCK_REG_OFFSET, 30U),   /*!< WWDGT reset flags */
-	RCU_FLAG_LPRST = RCU_REGIDX_BIT(RSTSCK_REG_OFFSET, 31U),      /*!< low-power reset flags */
+    /* clock stabilization flags */
+    RCU_FLAG_IRC8MSTB = RCU_REGIDX_BIT(CTL_REG_OFFSET, 1U),       /*!< IRC8M stabilization flags */
+    RCU_FLAG_HXTALSTB = RCU_REGIDX_BIT(CTL_REG_OFFSET, 17U),      /*!< HXTAL stabilization flags */
+    RCU_FLAG_PLLSTB = RCU_REGIDX_BIT(CTL_REG_OFFSET, 25U),        /*!< PLL stabilization flags */
+    RCU_FLAG_PLL1STB = RCU_REGIDX_BIT(CTL_REG_OFFSET, 27U),       /*!< PLL1 stabilization flags */
+    RCU_FLAG_PLL2STB = RCU_REGIDX_BIT(CTL_REG_OFFSET, 29U),       /*!< PLL2 stabilization flags */
+    RCU_FLAG_LXTALSTB = RCU_REGIDX_BIT(BDCTL_REG_OFFSET, 1U),     /*!< LXTAL stabilization flags */
+    RCU_FLAG_IRC40KSTB = RCU_REGIDX_BIT(RSTSCK_REG_OFFSET, 1U),   /*!< IRC40K stabilization flags */
+    /* reset source flags */
+    RCU_FLAG_EPRST = RCU_REGIDX_BIT(RSTSCK_REG_OFFSET, 26U),      /*!< external PIN reset flags */
+    RCU_FLAG_PORRST = RCU_REGIDX_BIT(RSTSCK_REG_OFFSET, 27U),     /*!< power reset flags */
+    RCU_FLAG_SWRST = RCU_REGIDX_BIT(RSTSCK_REG_OFFSET, 28U),      /*!< software reset flags */
+    RCU_FLAG_FWDGTRST = RCU_REGIDX_BIT(RSTSCK_REG_OFFSET, 29U),   /*!< FWDGT reset flags */
+    RCU_FLAG_WWDGTRST = RCU_REGIDX_BIT(RSTSCK_REG_OFFSET, 30U),   /*!< WWDGT reset flags */
+    RCU_FLAG_LPRST = RCU_REGIDX_BIT(RSTSCK_REG_OFFSET, 31U),      /*!< low-power reset flags */
 } rcu_flag_enum;
 
 /* clock stabilization and ckm interrupt flags */
 typedef enum {
-	RCU_INT_FLAG_IRC40KSTB = RCU_REGIDX_BIT(INT_REG_OFFSET, 0U),  /*!< IRC40K stabilization interrupt flag */
-	RCU_INT_FLAG_LXTALSTB = RCU_REGIDX_BIT(INT_REG_OFFSET, 1U),   /*!< LXTAL stabilization interrupt flag */
-	RCU_INT_FLAG_IRC8MSTB = RCU_REGIDX_BIT(INT_REG_OFFSET, 2U),   /*!< IRC8M stabilization interrupt flag */
-	RCU_INT_FLAG_HXTALSTB = RCU_REGIDX_BIT(INT_REG_OFFSET, 3U),   /*!< HXTAL stabilization interrupt flag */
-	RCU_INT_FLAG_PLLSTB = RCU_REGIDX_BIT(INT_REG_OFFSET, 4U),     /*!< PLL stabilization interrupt flag */
-	RCU_INT_FLAG_PLL1STB = RCU_REGIDX_BIT(INT_REG_OFFSET, 5U),    /*!< PLL1 stabilization interrupt flag */
-	RCU_INT_FLAG_PLL2STB = RCU_REGIDX_BIT(INT_REG_OFFSET, 6U),    /*!< PLL2 stabilization interrupt flag */
-	RCU_INT_FLAG_CKM = RCU_REGIDX_BIT(INT_REG_OFFSET, 7U),        /*!< HXTAL clock stuck interrupt flag */
+    RCU_INT_FLAG_IRC40KSTB = RCU_REGIDX_BIT(INT_REG_OFFSET, 0U),  /*!< IRC40K stabilization interrupt flag */
+    RCU_INT_FLAG_LXTALSTB = RCU_REGIDX_BIT(INT_REG_OFFSET, 1U),   /*!< LXTAL stabilization interrupt flag */
+    RCU_INT_FLAG_IRC8MSTB = RCU_REGIDX_BIT(INT_REG_OFFSET, 2U),   /*!< IRC8M stabilization interrupt flag */
+    RCU_INT_FLAG_HXTALSTB = RCU_REGIDX_BIT(INT_REG_OFFSET, 3U),   /*!< HXTAL stabilization interrupt flag */
+    RCU_INT_FLAG_PLLSTB = RCU_REGIDX_BIT(INT_REG_OFFSET, 4U),     /*!< PLL stabilization interrupt flag */
+    RCU_INT_FLAG_PLL1STB = RCU_REGIDX_BIT(INT_REG_OFFSET, 5U),    /*!< PLL1 stabilization interrupt flag */
+    RCU_INT_FLAG_PLL2STB = RCU_REGIDX_BIT(INT_REG_OFFSET, 6U),    /*!< PLL2 stabilization interrupt flag */
+    RCU_INT_FLAG_CKM = RCU_REGIDX_BIT(INT_REG_OFFSET, 7U),        /*!< HXTAL clock stuck interrupt flag */
 } rcu_int_flag_enum;
 
 /* clock stabilization and stuck interrupt flags clear */
 typedef enum {
-	RCU_INT_FLAG_IRC40KSTB_CLR = RCU_REGIDX_BIT(INT_REG_OFFSET, 16U), /*!< IRC40K stabilization interrupt flags clear */
-	RCU_INT_FLAG_LXTALSTB_CLR = RCU_REGIDX_BIT(INT_REG_OFFSET, 17U),  /*!< LXTAL stabilization interrupt flags clear */
-	RCU_INT_FLAG_IRC8MSTB_CLR = RCU_REGIDX_BIT(INT_REG_OFFSET, 18U),  /*!< IRC8M stabilization interrupt flags clear */
-	RCU_INT_FLAG_HXTALSTB_CLR = RCU_REGIDX_BIT(INT_REG_OFFSET, 19U),  /*!< HXTAL stabilization interrupt flags clear */
-	RCU_INT_FLAG_PLLSTB_CLR = RCU_REGIDX_BIT(INT_REG_OFFSET, 20U),    /*!< PLL stabilization interrupt flags clear */
-	RCU_INT_FLAG_PLL1STB_CLR = RCU_REGIDX_BIT(INT_REG_OFFSET, 21U),   /*!< PLL1 stabilization interrupt flags clear */
-	RCU_INT_FLAG_PLL2STB_CLR = RCU_REGIDX_BIT(INT_REG_OFFSET, 22U),   /*!< PLL2 stabilization interrupt flags clear */
-	RCU_INT_FLAG_CKM_CLR = RCU_REGIDX_BIT(INT_REG_OFFSET, 23U),       /*!< CKM interrupt flags clear */
+    RCU_INT_FLAG_IRC40KSTB_CLR = RCU_REGIDX_BIT(INT_REG_OFFSET, 16U), /*!< IRC40K stabilization interrupt flags clear */
+    RCU_INT_FLAG_LXTALSTB_CLR = RCU_REGIDX_BIT(INT_REG_OFFSET, 17U),  /*!< LXTAL stabilization interrupt flags clear */
+    RCU_INT_FLAG_IRC8MSTB_CLR = RCU_REGIDX_BIT(INT_REG_OFFSET, 18U),  /*!< IRC8M stabilization interrupt flags clear */
+    RCU_INT_FLAG_HXTALSTB_CLR = RCU_REGIDX_BIT(INT_REG_OFFSET, 19U),  /*!< HXTAL stabilization interrupt flags clear */
+    RCU_INT_FLAG_PLLSTB_CLR = RCU_REGIDX_BIT(INT_REG_OFFSET, 20U),    /*!< PLL stabilization interrupt flags clear */
+    RCU_INT_FLAG_PLL1STB_CLR = RCU_REGIDX_BIT(INT_REG_OFFSET, 21U),   /*!< PLL1 stabilization interrupt flags clear */
+    RCU_INT_FLAG_PLL2STB_CLR = RCU_REGIDX_BIT(INT_REG_OFFSET, 22U),   /*!< PLL2 stabilization interrupt flags clear */
+    RCU_INT_FLAG_CKM_CLR = RCU_REGIDX_BIT(INT_REG_OFFSET, 23U),       /*!< CKM interrupt flags clear */
 } rcu_int_flag_clear_enum;
 
 /* clock stabilization interrupt enable or disable */
 typedef enum {
-	RCU_INT_IRC40KSTB = RCU_REGIDX_BIT(INT_REG_OFFSET, 8U),  /*!< IRC40K stabilization interrupt */
-	RCU_INT_LXTALSTB = RCU_REGIDX_BIT(INT_REG_OFFSET, 9U),   /*!< LXTAL stabilization interrupt */
-	RCU_INT_IRC8MSTB = RCU_REGIDX_BIT(INT_REG_OFFSET, 10U),  /*!< IRC8M stabilization interrupt */
-	RCU_INT_HXTALSTB = RCU_REGIDX_BIT(INT_REG_OFFSET, 11U),  /*!< HXTAL stabilization interrupt */
-	RCU_INT_PLLSTB = RCU_REGIDX_BIT(INT_REG_OFFSET, 12U),    /*!< PLL stabilization interrupt */
-	RCU_INT_PLL1STB = RCU_REGIDX_BIT(INT_REG_OFFSET, 13U),   /*!< PLL1 stabilization interrupt */
-	RCU_INT_PLL2STB = RCU_REGIDX_BIT(INT_REG_OFFSET, 14U),   /*!< PLL2 stabilization interrupt */
+    RCU_INT_IRC40KSTB = RCU_REGIDX_BIT(INT_REG_OFFSET, 8U),  /*!< IRC40K stabilization interrupt */
+    RCU_INT_LXTALSTB = RCU_REGIDX_BIT(INT_REG_OFFSET, 9U),   /*!< LXTAL stabilization interrupt */
+    RCU_INT_IRC8MSTB = RCU_REGIDX_BIT(INT_REG_OFFSET, 10U),  /*!< IRC8M stabilization interrupt */
+    RCU_INT_HXTALSTB = RCU_REGIDX_BIT(INT_REG_OFFSET, 11U),  /*!< HXTAL stabilization interrupt */
+    RCU_INT_PLLSTB = RCU_REGIDX_BIT(INT_REG_OFFSET, 12U),    /*!< PLL stabilization interrupt */
+    RCU_INT_PLL1STB = RCU_REGIDX_BIT(INT_REG_OFFSET, 13U),   /*!< PLL1 stabilization interrupt */
+    RCU_INT_PLL2STB = RCU_REGIDX_BIT(INT_REG_OFFSET, 14U),   /*!< PLL2 stabilization interrupt */
 } rcu_int_enum;
 
 /* oscillator types */

--- a/SoC/gd32vf103/Common/Include/gd32vf103_usart.h
+++ b/SoC/gd32vf103/Common/Include/gd32vf103_usart.h
@@ -130,10 +130,10 @@ OF SUCH DAMAGE.
 #define USART_BIT_POS2(val)                  (((uint32_t)(val) & (0x001F0000U)) >> 16)
 
 /* register offset */
-#define USART_STAT_REG_OFFSET                     (0x00000000U)        	/*!< STAT register offset */
-#define USART_CTL0_REG_OFFSET                     (0x0000000CU)        	/*!< CTL0 register offset */
-#define USART_CTL1_REG_OFFSET                     (0x00000010U)        	/*!< CTL1 register offset */
-#define USART_CTL2_REG_OFFSET                     (0x00000014U)        	/*!< CTL2 register offset */
+#define USART_STAT_REG_OFFSET                     (0x00000000U)            /*!< STAT register offset */
+#define USART_CTL0_REG_OFFSET                     (0x0000000CU)            /*!< CTL0 register offset */
+#define USART_CTL1_REG_OFFSET                     (0x00000010U)            /*!< CTL1 register offset */
+#define USART_CTL2_REG_OFFSET                     (0x00000014U)            /*!< CTL2 register offset */
 
 /* USART flags */
 typedef enum

--- a/SoC/gd32vf103/Common/Source/Drivers/gd32vf103_can.c
+++ b/SoC/gd32vf103/Common/Source/Drivers/gd32vf103_can.c
@@ -915,9 +915,9 @@ FlagStatus can_flag_get(uint32_t can_periph, can_flag_enum flag)
       \arg        CAN_FLAG_RFF0: receive FIFO0 full
       \arg        CAN_FLAG_RFO1: receive FIFO1 overfull
       \arg        CAN_FLAG_RFF1: receive FIFO1 full
-      \arg		  CAN_FLAG_BOERR: bus-off error
-	  \arg		  CAN_FLAG_PERR: passive error
-	  \arg		  CAN_FLAG_WERR: warning error
+      \arg          CAN_FLAG_BOERR: bus-off error
+      \arg          CAN_FLAG_PERR: passive error
+      \arg          CAN_FLAG_WERR: warning error
     \param[out] none
     \retval     none
 */
@@ -947,8 +947,8 @@ void can_flag_clear(uint32_t can_periph, can_flag_enum flag)
 */
 FlagStatus can_interrupt_flag_get(uint32_t can_periph, can_interrupt_flag_enum flag)
 {  
-	uint32_t ret1 = RESET;
-	uint32_t ret2 = RESET;
+    uint32_t ret1 = RESET;
+    uint32_t ret2 = RESET;
     
     /* get the staus of interrupt flag */
     ret1 = CAN_REG_VALS(can_periph, flag) & BIT(CAN_BIT_POS0(flag));
@@ -977,9 +977,9 @@ FlagStatus can_interrupt_flag_get(uint32_t can_periph, can_interrupt_flag_enum f
       \arg        CAN_INT_FLAG_RFF0: receive FIFO0 full interrupt flag
       \arg        CAN_INT_FLAG_RFO1: receive FIFO1 overfull interrupt flag
       \arg        CAN_INT_FLAG_RFF1: receive FIFO1 full interrupt flag
-	  \arg		  CAN_FLAG_BOERR: bus-off error
-	  \arg		  CAN_FLAG_PERR: passive error
-	  \arg		  CAN_FLAG_WERR: warning error
+      \arg          CAN_FLAG_BOERR: bus-off error
+      \arg          CAN_FLAG_PERR: passive error
+      \arg          CAN_FLAG_WERR: warning error
     \param[out] none
     \retval     none
 */

--- a/SoC/gd32vf103/Common/Source/Drivers/gd32vf103_dma.c
+++ b/SoC/gd32vf103/Common/Source/Drivers/gd32vf103_dma.c
@@ -51,18 +51,18 @@ static ErrStatus dma_periph_and_channel_check(uint32_t dma_periph, dma_channel_e
 */
 void dma_deinit(uint32_t dma_periph, dma_channel_enum channelx)
 {
-	if(ERROR == dma_periph_and_channel_check(dma_periph, channelx)){
-		DMA_WRONG_HANDLE
-	}
+    if(ERROR == dma_periph_and_channel_check(dma_periph, channelx)){
+        DMA_WRONG_HANDLE
+    }
 
-	/* disable DMA a channel */
-	DMA_CHCTL(dma_periph, channelx) &= ~DMA_CHXCTL_CHEN;
-	/* reset DMA channel registers */
-	DMA_CHCTL(dma_periph, channelx) = DMA_CHCTL_RESET_VALUE;
-	DMA_CHCNT(dma_periph, channelx) = DMA_CHCNT_RESET_VALUE;
-	DMA_CHPADDR(dma_periph, channelx) = DMA_CHPADDR_RESET_VALUE;
-	DMA_CHMADDR(dma_periph, channelx) = DMA_CHMADDR_RESET_VALUE;
-	DMA_INTC(dma_periph) |= DMA_FLAG_ADD(DMA_CHINTF_RESET_VALUE, channelx);
+    /* disable DMA a channel */
+    DMA_CHCTL(dma_periph, channelx) &= ~DMA_CHXCTL_CHEN;
+    /* reset DMA channel registers */
+    DMA_CHCTL(dma_periph, channelx) = DMA_CHCTL_RESET_VALUE;
+    DMA_CHCNT(dma_periph, channelx) = DMA_CHCNT_RESET_VALUE;
+    DMA_CHPADDR(dma_periph, channelx) = DMA_CHPADDR_RESET_VALUE;
+    DMA_CHMADDR(dma_periph, channelx) = DMA_CHMADDR_RESET_VALUE;
+    DMA_INTC(dma_periph) |= DMA_FLAG_ADD(DMA_CHINTF_RESET_VALUE, channelx);
 }
 
 /*!
@@ -607,34 +607,34 @@ void dma_flag_clear(uint32_t dma_periph, dma_channel_enum channelx, uint32_t fla
 */
 FlagStatus dma_interrupt_flag_get(uint32_t dma_periph, dma_channel_enum channelx, uint32_t flag)
 {
-	uint32_t interrupt_enable = 0U, interrupt_flag = 0U;
+    uint32_t interrupt_enable = 0U, interrupt_flag = 0U;
 
-	switch(flag){
-		case DMA_INT_FLAG_FTF:
-			/* check whether the full transfer finish interrupt flag is set and enabled */
-			interrupt_flag = DMA_INTF(dma_periph) & DMA_FLAG_ADD(flag, channelx);
-			interrupt_enable = DMA_CHCTL(dma_periph, channelx) & DMA_CHXCTL_FTFIE;
-			break;
-		case DMA_INT_FLAG_HTF:
-			/* check whether the half transfer finish interrupt flag is set and enabled */
-			interrupt_flag = DMA_INTF(dma_periph) & DMA_FLAG_ADD(flag, channelx);
-			interrupt_enable = DMA_CHCTL(dma_periph, channelx) & DMA_CHXCTL_HTFIE;
-			break;
-		case DMA_INT_FLAG_ERR:
-			/* check whether the error interrupt flag is set and enabled */
-			interrupt_flag = DMA_INTF(dma_periph) & DMA_FLAG_ADD(flag, channelx);
-			interrupt_enable = DMA_CHCTL(dma_periph, channelx) & DMA_CHXCTL_ERRIE;
-			break;
-		default:
-			DMA_WRONG_HANDLE
-	}
+    switch(flag){
+        case DMA_INT_FLAG_FTF:
+            /* check whether the full transfer finish interrupt flag is set and enabled */
+            interrupt_flag = DMA_INTF(dma_periph) & DMA_FLAG_ADD(flag, channelx);
+            interrupt_enable = DMA_CHCTL(dma_periph, channelx) & DMA_CHXCTL_FTFIE;
+            break;
+        case DMA_INT_FLAG_HTF:
+            /* check whether the half transfer finish interrupt flag is set and enabled */
+            interrupt_flag = DMA_INTF(dma_periph) & DMA_FLAG_ADD(flag, channelx);
+            interrupt_enable = DMA_CHCTL(dma_periph, channelx) & DMA_CHXCTL_HTFIE;
+            break;
+        case DMA_INT_FLAG_ERR:
+            /* check whether the error interrupt flag is set and enabled */
+            interrupt_flag = DMA_INTF(dma_periph) & DMA_FLAG_ADD(flag, channelx);
+            interrupt_enable = DMA_CHCTL(dma_periph, channelx) & DMA_CHXCTL_ERRIE;
+            break;
+        default:
+            DMA_WRONG_HANDLE
+    }
 
-	/* when the interrupt flag is set and enabled, return SET */
-	if(interrupt_flag && interrupt_enable){
-		return SET;
-	}else{
-		return RESET;
-	}
+    /* when the interrupt flag is set and enabled, return SET */
+    if(interrupt_flag && interrupt_enable){
+        return SET;
+    }else{
+        return RESET;
+    }
 }
 
 /*!

--- a/SoC/gd32vf103/Common/Source/Drivers/gd32vf103_pmu.c
+++ b/SoC/gd32vf103/Common/Source/Drivers/gd32vf103_pmu.c
@@ -105,7 +105,7 @@ void pmu_to_sleepmode(uint8_t sleepmodecmd)
         __WFI();
     }else{
         __disable_irq();
-	__WFE();
+    __WFE();
         __enable_irq();
     }
 }
@@ -136,7 +136,7 @@ void pmu_to_deepsleepmode(uint32_t ldo,uint8_t deepsleepmodecmd)
         __WFI();
     }else{
         __disable_irq();
-	__WFE();
+    __WFE();
         __enable_irq();
     }
     /* reset sleepdeep bit of RISC-V system control register */
@@ -168,7 +168,7 @@ void pmu_to_standbymode(uint8_t standbymodecmd)
         __WFI();
     }else{
         __disable_irq();
-	__WFE();
+    __WFE();
         __enable_irq();
     }
     __RV_CSR_CLEAR(CSR_WFE, WFE_WFE);


### PR DESCRIPTION
As requested from @fanghuaqi in https://github.com/Nuclei-Software/nuclei-sdk/pull/17#pullrequestreview-542554615, I also replaced all TABs with spaces in subfolder SoC to meet the styleguide.
