### PR TITLE
nmsis: Replace TABs with spaces.

### DIFF
--- a/NMSIS/Core/Include/riscv_encoding.h
+++ b/NMSIS/Core/Include/riscv_encoding.h
@@ -270,17 +270,17 @@
 
 
 /* === PMP CFG Bits === */
-#define PMP_R				0x01
-#define PMP_W				0x02
-#define PMP_X				0x04
-#define PMP_A				0x18
-#define PMP_A_TOR			0x08
-#define PMP_A_NA4			0x10
-#define PMP_A_NAPOT			0x18
-#define PMP_L				0x80
+#define PMP_R                0x01
+#define PMP_W                0x02
+#define PMP_X                0x04
+#define PMP_A                0x18
+#define PMP_A_TOR            0x08
+#define PMP_A_NA4            0x10
+#define PMP_A_NAPOT          0x18
+#define PMP_L                0x80
 
-#define PMP_SHIFT			2
-#define PMP_COUNT			16
+#define PMP_SHIFT            2
+#define PMP_COUNT            16
 
 // page table entry (PTE) fields
 #define PTE_V     0x001 // Valid
@@ -329,7 +329,7 @@
  *   @{
  */
 /* === Standard RISC-V CSR Registers === */
-#define CSR_USTATUS	0x0
+#define CSR_USTATUS 0x0
 #define CSR_FFLAGS 0x1
 #define CSR_FRM 0x2
 #define CSR_FCSR 0x3
@@ -387,10 +387,10 @@
 #define CSR_MBADADDR 0x343
 #define CSR_MTVAL 0x343
 #define CSR_MIP 0x344
-#define CSR_PMPCFG0	0x3a0
-#define CSR_PMPCFG1	0x3a1
-#define CSR_PMPCFG2	0x3a2
-#define CSR_PMPCFG3	0x3a3
+#define CSR_PMPCFG0 0x3a0
+#define CSR_PMPCFG1 0x3a1
+#define CSR_PMPCFG2 0x3a2
+#define CSR_PMPCFG3 0x3a3
 #define CSR_PMPADDR0 0x3b0
 #define CSR_PMPADDR1 0x3b1
 #define CSR_PMPADDR2 0x3b2

--- a/NMSIS/DSP/Include/riscv_math.h
+++ b/NMSIS/DSP/Include/riscv_math.h
@@ -439,8 +439,8 @@ __STATIC_FORCEINLINE q63_t read_q31x2 (
   @return        none
  */
 __STATIC_FORCEINLINE void write_q31x2_ia (
-		q31_t ** pQ31,
-		q63_t    value)
+        q31_t ** pQ31,
+        q63_t    value)
 {
 #ifndef RISCV_ALIGN_ACCESS
 #if __RISCV_XLEN == 64
@@ -461,8 +461,8 @@ __STATIC_FORCEINLINE void write_q31x2_ia (
   @return        none
  */
 __STATIC_FORCEINLINE void write_q31x2 (
-		q31_t * pQ31,
-		q63_t value)
+        q31_t * pQ31,
+        q63_t value)
 {
 #ifndef RISCV_ALIGN_ACCESS
 #if __RISCV_XLEN == 64
@@ -527,7 +527,7 @@ __STATIC_FORCEINLINE q31_t read_q15x2_ia (
   @return        Q63 value
  */
 __STATIC_FORCEINLINE q63_t read_q15x4_ia (
-		q15_t ** pQ15)
+        q15_t ** pQ15)
 {
   q63_t val;
 #ifndef RISCV_ALIGN_ACCESS
@@ -546,7 +546,7 @@ __STATIC_FORCEINLINE q63_t read_q15x4_ia (
   @return        Q63 value
  */
 __STATIC_FORCEINLINE q63_t read_q15x4 (
-		q15_t * pQ15)
+        q15_t * pQ15)
 {
   q63_t val;
 #ifndef RISCV_ALIGN_ACCESS
@@ -591,17 +591,17 @@ __STATIC_FORCEINLINE q31_t read_q15x2_da (
   @return        Q31 value
  */
 __STATIC_FORCEINLINE q63_t read_q15x4_da (
-		q15_t ** pQ15)
+        q15_t ** pQ15)
 {
-	q63_t val;
+    q63_t val;
 #ifndef RISCV_ALIGN_ACCESS
-	val = *((q63_t *)*pQ15);
+    val = *((q63_t *)*pQ15);
 #else
     memcpy((void *)(&val), (void *)(*pQ15), 8);
 #endif
-	*pQ15 -= 4;
+    *pQ15 -= 4;
 
-	return (val);
+    return (val);
 }
 
 /**
@@ -617,9 +617,9 @@ __STATIC_FORCEINLINE void write_q15x2_ia (
 #ifndef RISCV_ALIGN_ACCESS
   __ASM volatile (
     "sw %0, (%1)"
-	:
-	:"r"(value), "r"(*pQ15)
-	:"memory"
+    :
+    :"r"(value), "r"(*pQ15)
+    :"memory"
   );
 #else
   memcpy((void *)(*pQ15), (void *)(&value), 4);
@@ -634,15 +634,15 @@ __STATIC_FORCEINLINE void write_q15x2_ia (
   @return        none
  */
 __STATIC_FORCEINLINE void write_q15x4_ia (
-		q15_t ** pQ15,
-		q63_t    value)
+        q15_t ** pQ15,
+        q63_t    value)
 {
 #ifndef RISCV_ALIGN_ACCESS
-	*((q63_t *)*pQ15) = value;
+    *((q63_t *)*pQ15) = value;
 #else
     memcpy((void *)(*pQ15), (void *)(&value), 8);
 #endif
-	*pQ15 += 4;
+    *pQ15 += 4;
 }
 
 /**
@@ -652,15 +652,15 @@ __STATIC_FORCEINLINE void write_q15x4_ia (
   @return        none
  */
 __STATIC_FORCEINLINE void write_q15x4_da (
-		q15_t ** pQ15,
-		q63_t    value)
+        q15_t ** pQ15,
+        q63_t    value)
 {
 #ifndef RISCV_ALIGN_ACCESS
-	*((q63_t *)*pQ15) = value;
+    *((q63_t *)*pQ15) = value;
 #else
     memcpy((void *)(*pQ15), (void *)(&value), 8);
 #endif
-	*pQ15 -= 4;
+    *pQ15 -= 4;
 }
 
 /**
@@ -676,9 +676,9 @@ __STATIC_FORCEINLINE void write_q15x2 (
 #ifndef RISCV_ALIGN_ACCESS
   __ASM volatile (
     "sw %0, (%1)"
-	:
-	:"r"(value), "r"(pQ15)
-	:"memory"
+    :
+    :"r"(value), "r"(pQ15)
+    :"memory"
   );
 #else
   memcpy((void *)(pQ15), (void *)(&value), 4);
@@ -693,8 +693,8 @@ __STATIC_FORCEINLINE void write_q15x2 (
   @return        none
  */
 __STATIC_FORCEINLINE void write_q15x4 (
-		q15_t * pQ15,
-		q63_t   value)
+        q15_t * pQ15,
+        q63_t   value)
 {
 #ifndef RISCV_ALIGN_ACCESS
   *((q63_t *)pQ15) = value;
@@ -709,17 +709,17 @@ __STATIC_FORCEINLINE void write_q15x4 (
   @return        Q63 value
  */
 __STATIC_FORCEINLINE q63_t read_q7x8_ia (
-		q7_t ** pQ7)
+        q7_t ** pQ7)
 {
-	q63_t val;
+    q63_t val;
 #ifndef RISCV_ALIGN_ACCESS
-	val = *((q63_t *)*pQ7);
+    val = *((q63_t *)*pQ7);
 #else
     memcpy((void *)(&val), (void *)(*pQ7), 8);
 #endif
-	*pQ7 += 8;
+    *pQ7 += 8;
 
-	return val;
+    return val;
 }
 
 /**
@@ -728,16 +728,16 @@ __STATIC_FORCEINLINE q63_t read_q7x8_ia (
   @return        Q63 value
  */
 __STATIC_FORCEINLINE q63_t read_q7x8_da (
-		q7_t ** pQ7)
+        q7_t ** pQ7)
 {
-	q63_t val;
+    q63_t val;
 #ifndef RISCV_ALIGN_ACCESS
-	val = *((q63_t *)*pQ7);
+    val = *((q63_t *)*pQ7);
 #else
     memcpy((void *)(&val), (void *)(*pQ7), 8);
 #endif
-	*pQ7 -= 8;
-	return val;
+    *pQ7 -= 8;
+    return val;
 }
 
 /**
@@ -795,15 +795,15 @@ __STATIC_FORCEINLINE q31_t read_q7x4_da (
   @return        none
  */
 __STATIC_FORCEINLINE void write_q7x8_ia (
-		q7_t ** pQ7,
-		q63_t   value)
+        q7_t ** pQ7,
+        q63_t   value)
 {
 #ifndef RISCV_ALIGN_ACCESS
-	*((q63_t *)*pQ7) = value;
+    *((q63_t *)*pQ7) = value;
 #else
     memcpy((void *)(*pQ7), (void *)(&value), 8);
 #endif
-	*pQ7 += 8;
+    *pQ7 += 8;
 }
 
 /**


### PR DESCRIPTION
As requested from @fanghuaqi in https://github.com/Nuclei-Software/nuclei-sdk/pull/17#pullrequestreview-542554615, I also replaced all TABs with spaces in subfolder NMSIS to meet the styleguide.
