### PR TITLE
Fix -Wundef warnings for __riscv_flen

### DIFF
--- a/NMSIS/Core/Include/riscv_bits.h
+++ b/NMSIS/Core/Include/riscv_bits.h
@@ -38,6 +38,7 @@
 
 #define REGBYTES (1 << LOG_REGBYTES)
 
+#if defined(__riscv_flen)
 #if __riscv_flen == 64
 # define FPSTORE                fsd
 # define FPLOAD                 fld
@@ -48,6 +49,7 @@
 # define LOG_FPREGBYTES         2
 #endif /* __riscv_flen */
 #define FPREGBYTES              (1 << LOG_FPREGBYTES)
+#endif
 
 #define __rv_likely(x)          __builtin_expect((x), 1)
 #define __rv_unlikely(x)        __builtin_expect((x), 0)

--- a/application/baremetal/benchmark/whetstone/config.h
+++ b/application/baremetal/benchmark/whetstone/config.h
@@ -11,7 +11,7 @@
  * 32: if F toolchain is used
  */
 
-#if __riscv_flen == 64
+#if defined(__riscv_flen) && __riscv_flen == 64
 #define SPDP double
 #define Precision "Double"
 #else //__riscv_flen == 32


### PR DESCRIPTION
This guards the floating point defines in `riscv_bits.h`, because `__riscv_flen` is undefined for archs that don't have them. 

I ran into trouble in a project that has `-Werror` and `-Wundef` defined, defining `__riscv_flen` as 0 has the side effect that a non existent csr is accessed in the [startup code](https://github.com/Nuclei-Software/nuclei-sdk/blob/master/SoC/gd32vf103/Common/Source/GCC/startup_gd32vf103.S#L289-L294) which results in a runtime exception.