### PR TITLE
Fix register masking and warnings

### DIFF
--- a/SoC/gd32vf103/Common/Source/Drivers/Usb/drv_usbd_int.c
+++ b/SoC/gd32vf103/Common/Source/Drivers/Usb/drv_usbd_int.c
@@ -80,7 +80,7 @@ uint32_t USBD_OTG_EP1OUT_ISR_Handler(usb_core_driver* udev)
 
             /* ToDo : handle more than one single MPS size packet */
             udev->dev.transc_out[1].xfer_count = udev->dev.transc_out[1].usb_transc - \
-                                                 oeplen & DEPLEN_TLEN;
+                                                 (oeplen & DEPLEN_TLEN);
         }
 
         /* RX COMPLETE */
@@ -274,7 +274,7 @@ static uint32_t usbd_int_epout(usb_core_driver* udev)
                     __IO uint32_t eplen = udev->regs.er_out[ep_num]->DOEPLEN;
 
                     udev->dev.transc_out[ep_num].xfer_count = udev->dev.transc_out[ep_num].max_len - \
-                                                              eplen & DEPLEN_TLEN;
+                                                              (eplen & DEPLEN_TLEN);
                 }
 
                 /* inform upper layer: data ready */

--- a/SoC/gd32vf103/Common/Source/Drivers/Usb/drv_usbh_int.c
+++ b/SoC/gd32vf103/Common/Source/Drivers/Usb/drv_usbh_int.c
@@ -386,7 +386,7 @@ uint32_t usbh_int_pipe_in(usb_core_driver* pudev, uint32_t pp_num)
         usb_pp_halt(pudev, pp_num, HCHINTF_REQOVR, PIPE_REQOVR);
     } else if (intr_pp & HCHINTF_TF) {
         if (USB_USE_DMA == pudev->bp.transfer_mode) {
-            pudev->host.backup_xfercount[pp_num] = pp->xfer_len - pp_reg->HCHLEN & HCHLEN_TLEN;
+            pudev->host.backup_xfercount[pp_num] = pp->xfer_len - (pp_reg->HCHLEN & HCHLEN_TLEN);
         }
 
         pp->pp_status = PIPE_XF;

--- a/SoC/gd32vf103/Common/Source/Drivers/gd32vf103_i2c.c
+++ b/SoC/gd32vf103/Common/Source/Drivers/gd32vf103_i2c.c
@@ -607,11 +607,10 @@ FlagStatus i2c_flag_get(uint32_t i2c_periph, i2c_flag_enum flag)
  */
 void i2c_flag_clear(uint32_t i2c_periph, i2c_flag_enum flag)
 {
-    uint32_t temp;
     if (I2C_FLAG_ADDSEND == flag) {
         /* read I2C_STAT0 and then read I2C_STAT1 to clear ADDSEND */
-        temp = I2C_STAT0(i2c_periph);
-        temp = I2C_STAT1(i2c_periph);
+        I2C_STAT0(i2c_periph);
+        I2C_STAT1(i2c_periph);
     } else {
         I2C_REG_VAL(i2c_periph, flag) &= ~BIT(I2C_BIT_POS(flag));
     }
@@ -715,11 +714,10 @@ FlagStatus i2c_interrupt_flag_get(uint32_t i2c_periph, i2c_interrupt_flag_enum i
  */
 void i2c_interrupt_flag_clear(uint32_t i2c_periph, i2c_interrupt_flag_enum int_flag)
 {
-    uint32_t temp;
     if (I2C_INT_FLAG_ADDSEND == int_flag) {
         /* read I2C_STAT0 and then read I2C_STAT1 to clear ADDSEND */
-        temp = I2C_STAT0(i2c_periph);
-        temp = I2C_STAT1(i2c_periph);
+        I2C_STAT0(i2c_periph);
+        I2C_STAT1(i2c_periph);
     } else {
         I2C_REG_VAL2(i2c_periph, int_flag) &= ~BIT(I2C_BIT_POS2(int_flag));
     }

--- a/SoC/gd32vf103/Common/Source/system_gd32vf103.c
+++ b/SoC/gd32vf103/Common/Source/system_gd32vf103.c
@@ -23,6 +23,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <inttypes.h>
 #include <stdint.h>
 #include <stdio.h>
 #include "nuclei_sdk_hal.h"
@@ -453,7 +454,7 @@ void SystemBannerPrint(void)
 #ifdef DOWNLOAD_MODE_STRING
     printf("Download Mode: %s\r\n", DOWNLOAD_MODE_STRING);
 #endif
-    printf("CPU Frequency %u Hz\r\n", (unsigned int)SystemCoreClock);
+    printf("CPU Frequency %" PRIu32 " Hz\r\n", SystemCoreClock);
 #endif
 }
 


### PR DESCRIPTION
This pull-request fixes the masking of a length read from a register and makes the order of operations explicit.

It also fixes some other warnings.

I've created the pull-request against the develop branch.
Let me know if you prefer to have it against the master branch.