### PR TITLE
Wrap declarations when including from C++

### DIFF
--- a/SoC/gd32vf103/Common/Include/gd32vf103.h
+++ b/SoC/gd32vf103/Common/Include/gd32vf103.h
@@ -29,8 +29,14 @@
 #include <stddef.h>
 
 #ifdef __cplusplus
-extern "C" {
+#define GD32VF103_BEGIN_DECLS extern "C" {
+#define GD32VF103_END_DECLS   }
+#else
+#define GD32VF103_BEGIN_DECLS
+#define GD32VF103_END_DECLS
 #endif
+
+GD32VF103_BEGIN_DECLS
 
 /** @addtogroup gd32
   * @{
@@ -442,8 +448,6 @@ extern void delay_1ms(uint32_t count);
 
 /** @} */ /* End of group gd32vf103 */
 
-#ifdef __cplusplus
-}
-#endif
+GD32VF103_END_DECLS
 
 #endif  /* __GD32VF103_SOC_H__ */

--- a/SoC/gd32vf103/Common/Include/gd32vf103_adc.h
+++ b/SoC/gd32vf103/Common/Include/gd32vf103_adc.h
@@ -39,6 +39,8 @@ OF SUCH DAMAGE.
 #include "gd32vf103_rcu.h"
 #include "gd32vf103_dbg.h"
 
+GD32VF103_BEGIN_DECLS
+
 /* ADC definitions */
 #define ADC0                            ADC_BASE
 #define ADC1                            (ADC_BASE + 0x400U)
@@ -395,5 +397,7 @@ void adc_oversample_mode_config(uint32_t adc_periph, uint8_t mode, uint16_t shif
 void adc_oversample_mode_enable(uint32_t adc_periph);
 /* disable ADC oversample mode */
 void adc_oversample_mode_disable(uint32_t adc_periph);
+
+GD32VF103_END_DECLS
 
 #endif /* GD32VF103_ADC_H */

--- a/SoC/gd32vf103/Common/Include/gd32vf103_bkp.h
+++ b/SoC/gd32vf103/Common/Include/gd32vf103_bkp.h
@@ -39,6 +39,8 @@ OF SUCH DAMAGE.
 #include "gd32vf103_rcu.h"
 #include "gd32vf103_dbg.h"
 
+GD32VF103_BEGIN_DECLS
+
 /* BKP definitions */
 #define BKP                             BKP_BASE                 /*!< BKP base address */
 
@@ -224,5 +226,7 @@ void bkp_flag_clear(void);
 FlagStatus bkp_interrupt_flag_get(void);
 /* clear tamper interrupt flag state */
 void bkp_interrupt_flag_clear(void);
+
+GD32VF103_END_DECLS
 
 #endif /* GD32VF103_BKP_H */

--- a/SoC/gd32vf103/Common/Include/gd32vf103_can.h
+++ b/SoC/gd32vf103/Common/Include/gd32vf103_can.h
@@ -39,6 +39,8 @@ OF SUCH DAMAGE.
 #include "gd32vf103_rcu.h"
 #include "gd32vf103_dbg.h"
 
+GD32VF103_BEGIN_DECLS
+
 /* CAN definitions */
 #define CAN0                               CAN_BASE                      /*!< CAN0 base address */
 #define CAN1                               (CAN0 + 0x00000400U)          /*!< CAN1 base address */
@@ -716,5 +718,7 @@ FlagStatus can_interrupt_flag_get(uint32_t can_periph,
                                   can_interrupt_flag_enum flag);
 /* CAN clear interrupt flag state */
 void can_interrupt_flag_clear(uint32_t can_periph, can_interrupt_flag_enum flag);
+
+GD32VF103_END_DECLS
 
 #endif /* GD32VF103_CAN_H */

--- a/SoC/gd32vf103/Common/Include/gd32vf103_crc.h
+++ b/SoC/gd32vf103/Common/Include/gd32vf103_crc.h
@@ -40,6 +40,8 @@ OF SUCH DAMAGE.
 #include "gd32vf103_rcu.h"
 #include "gd32vf103_dbg.h"
 
+GD32VF103_BEGIN_DECLS
+
 /* CRC definitions */
 #define CRC                            CRC_BASE
 
@@ -76,5 +78,7 @@ void crc_free_data_register_write(uint8_t free_data);
 uint32_t crc_single_data_calculate(uint32_t sdata);
 /* calculate the CRC value of an array of 32-bit values */
 uint32_t crc_block_data_calculate(uint32_t array[], uint32_t size);
+
+GD32VF103_END_DECLS
 
 #endif /* GD32VF103_CRC_H */

--- a/SoC/gd32vf103/Common/Include/gd32vf103_dac.h
+++ b/SoC/gd32vf103/Common/Include/gd32vf103_dac.h
@@ -39,6 +39,8 @@ OF SUCH DAMAGE.
 #include "gd32vf103_rcu.h"
 #include "gd32vf103_dbg.h"
 
+GD32VF103_BEGIN_DECLS
+
 /* DACx(x=0,1) definitions */
 #define DAC                     DAC_BASE
 #define DAC0                    (0U)
@@ -240,5 +242,7 @@ void dac_concurrent_output_buffer_enable(void);
 void dac_concurrent_output_buffer_disable(void);
 /* set DAC concurrent mode data holding register value */
 void dac_concurrent_data_set(uint32_t dac_align, uint16_t data0, uint16_t data1);
+
+GD32VF103_END_DECLS
 
 #endif /* GD32VF103_DAC_H */

--- a/SoC/gd32vf103/Common/Include/gd32vf103_dbg.h
+++ b/SoC/gd32vf103/Common/Include/gd32vf103_dbg.h
@@ -38,6 +38,8 @@ OF SUCH DAMAGE.
 #include "gd32vf103.h"
 #include "gd32vf103_rcu.h"
 
+GD32VF103_BEGIN_DECLS
+
 
 /* DBG definitions */
 #define DBG                      DBG_BASE
@@ -106,5 +108,7 @@ void dbg_low_power_disable(uint32_t dbg_low_power);
 void dbg_periph_enable(dbg_periph_enum dbg_periph);
 /* disable peripheral behavior when the MCU is in debug mode */
 void dbg_periph_disable(dbg_periph_enum dbg_periph);
+
+GD32VF103_END_DECLS
 
 #endif /* GD32VF103_DBG_H */

--- a/SoC/gd32vf103/Common/Include/gd32vf103_dma.h
+++ b/SoC/gd32vf103/Common/Include/gd32vf103_dma.h
@@ -39,6 +39,8 @@ OF SUCH DAMAGE.
 #include "gd32vf103_rcu.h"
 #include "gd32vf103_dbg.h"
 
+GD32VF103_BEGIN_DECLS
+
 
 /* DMA definitions */
 #define DMA0                            (DMA_BASE)               /*!< DMA0 base address */
@@ -279,5 +281,7 @@ void dma_interrupt_flag_clear(uint32_t dma_periph, dma_channel_enum channelx, ui
 void dma_interrupt_enable(uint32_t dma_periph, dma_channel_enum channelx, uint32_t source);
 /* disable DMA interrupt */
 void dma_interrupt_disable(uint32_t dma_periph, dma_channel_enum channelx, uint32_t source);
+
+GD32VF103_END_DECLS
 
 #endif /* GD32VF103_DMA_H */

--- a/SoC/gd32vf103/Common/Include/gd32vf103_exmc.h
+++ b/SoC/gd32vf103/Common/Include/gd32vf103_exmc.h
@@ -39,6 +39,8 @@ OF SUCH DAMAGE.
 #include "gd32vf103_rcu.h"
 #include "gd32vf103_dbg.h"
 
+GD32VF103_BEGIN_DECLS
+
 
 /* EXMC definitions */
 #define EXMC                              (EXMC_BASE)                   /*!< EXMC register base address */
@@ -123,5 +125,7 @@ void exmc_norsram_init(exmc_norsram_parameter_struct* exmc_norsram_init_struct);
 void exmc_norsram_enable(uint32_t norsram_region);
 /* EXMC NOR/SRAM bank disable */
 void exmc_norsram_disable(uint32_t norsram_region);
+
+GD32VF103_END_DECLS
 
 #endif /* GD32VF103_EXMC_H */

--- a/SoC/gd32vf103/Common/Include/gd32vf103_exti.h
+++ b/SoC/gd32vf103/Common/Include/gd32vf103_exti.h
@@ -39,6 +39,8 @@ OF SUCH DAMAGE.
 #include "gd32vf103_rcu.h"
 #include "gd32vf103_dbg.h"
 
+GD32VF103_BEGIN_DECLS
+
 
 /* EXTI definitions */
 #define EXTI                         EXTI_BASE
@@ -244,5 +246,7 @@ void exti_interrupt_flag_clear(exti_line_enum linex);
 void exti_software_interrupt_enable(exti_line_enum linex);
 /* disable the EXTI software interrupt event  */
 void exti_software_interrupt_disable(exti_line_enum linex);
+
+GD32VF103_END_DECLS
 
 #endif /* GD32VF103_EXTI_H */

--- a/SoC/gd32vf103/Common/Include/gd32vf103_fmc.h
+++ b/SoC/gd32vf103/Common/Include/gd32vf103_fmc.h
@@ -39,6 +39,8 @@ OF SUCH DAMAGE.
 #include "gd32vf103_rcu.h"
 #include "gd32vf103_dbg.h"
 
+GD32VF103_BEGIN_DECLS
+
 
 /* FMC and option byte definition */
 #define FMC                        FMC_BASE                        /*!< FMC register base address */
@@ -306,5 +308,7 @@ void fmc_interrupt_flag_clear(fmc_interrupt_flag_enum flag);
 fmc_state_enum fmc_state_get(void);
 /* check FMC ready or not */
 fmc_state_enum fmc_ready_wait(uint32_t timeout);
+
+GD32VF103_END_DECLS
 
 #endif /* GD32VF103_FMC_H */

--- a/SoC/gd32vf103/Common/Include/gd32vf103_fwdgt.h
+++ b/SoC/gd32vf103/Common/Include/gd32vf103_fwdgt.h
@@ -39,6 +39,8 @@ OF SUCH DAMAGE.
 #include "gd32vf103_rcu.h"
 #include "gd32vf103_dbg.h"
 
+GD32VF103_BEGIN_DECLS
+
 
 /* FWDGT definitions */
 #define FWDGT                       FWDGT_BASE                                /*!< FWDGT base address */
@@ -103,5 +105,7 @@ ErrStatus fwdgt_config(uint16_t reload_value, uint8_t prescaler_div);
 
 /* get flag state of FWDGT */
 FlagStatus fwdgt_flag_get(uint16_t flag);
+
+GD32VF103_END_DECLS
 
 #endif /* GD32VF103_FWDGT_H */

--- a/SoC/gd32vf103/Common/Include/gd32vf103_gpio.h
+++ b/SoC/gd32vf103/Common/Include/gd32vf103_gpio.h
@@ -39,6 +39,8 @@ OF SUCH DAMAGE.
 #include "gd32vf103_rcu.h"
 #include "gd32vf103_dbg.h"
 
+GD32VF103_BEGIN_DECLS
+
 /* GPIOx(x=A,B,C,D,E) definitions */
 #define GPIOA                      (GPIO_BASE + 0x00000000U)
 #define GPIOB                      (GPIO_BASE + 0x00000400U)
@@ -419,5 +421,7 @@ void gpio_event_output_disable(void);
 
 /* lock GPIO pin bit */
 void gpio_pin_lock(uint32_t gpio_periph, uint32_t pin);
+
+GD32VF103_END_DECLS
 
 #endif /* GD32VF103_GPIO_H */

--- a/SoC/gd32vf103/Common/Include/gd32vf103_i2c.h
+++ b/SoC/gd32vf103/Common/Include/gd32vf103_i2c.h
@@ -39,6 +39,8 @@ OF SUCH DAMAGE.
 #include "gd32vf103_rcu.h"
 #include "gd32vf103_dbg.h"
 
+GD32VF103_BEGIN_DECLS
+
 /* I2Cx(x=0,1) definitions */
 #define I2C0                          I2C_BASE                   /*!< I2C0 base address */
 #define I2C1                          (I2C_BASE + 0x00000400U)   /*!< I2C1 base address */
@@ -340,5 +342,7 @@ void i2c_interrupt_disable(uint32_t i2c_periph, i2c_interrupt_enum interrupt);
 FlagStatus i2c_interrupt_flag_get(uint32_t i2c_periph, i2c_interrupt_flag_enum int_flag);
 /* clear I2C interrupt flag */
 void i2c_interrupt_flag_clear(uint32_t i2c_periph, i2c_interrupt_flag_enum int_flag);
+
+GD32VF103_END_DECLS
 
 #endif /* GD32VF103_I2C_H */

--- a/SoC/gd32vf103/Common/Include/gd32vf103_libopt.h
+++ b/SoC/gd32vf103/Common/Include/gd32vf103_libopt.h
@@ -56,4 +56,8 @@ OF SUCH DAMAGE.
 #include "gd32vf103_usart.h"
 #include "gd32vf103_wwdgt.h"
 
+GD32VF103_BEGIN_DECLS
+
+GD32VF103_END_DECLS
+
 #endif /* GD32VF103_LIBOPT_H */

--- a/SoC/gd32vf103/Common/Include/gd32vf103_pmu.h
+++ b/SoC/gd32vf103/Common/Include/gd32vf103_pmu.h
@@ -39,6 +39,8 @@ OF SUCH DAMAGE.
 #include "gd32vf103_rcu.h"
 #include "gd32vf103_dbg.h"
 
+GD32VF103_BEGIN_DECLS
+
 /* PMU definitions */
 #define PMU                           PMU_BASE                 /*!< PMU base address */
 
@@ -123,5 +125,7 @@ void pmu_backup_write_disable(void);
 FlagStatus pmu_flag_get(uint32_t flag);
 /* clear flag bit */
 void pmu_flag_clear(uint32_t flag_reset);
+
+GD32VF103_END_DECLS
 
 #endif /* GD32VF103_PMU_H */

--- a/SoC/gd32vf103/Common/Include/gd32vf103_rcu.h
+++ b/SoC/gd32vf103/Common/Include/gd32vf103_rcu.h
@@ -37,6 +37,8 @@ OF SUCH DAMAGE.
 
 #include "gd32vf103.h"
 
+GD32VF103_BEGIN_DECLS
+
 /* RCU definitions */
 #define RCU                             RCU_BASE
 
@@ -756,5 +758,7 @@ void rcu_deepsleep_voltage_set(uint32_t dsvol);
 
 /* get the system clock, bus and peripheral clock frequency */
 uint32_t rcu_clock_freq_get(rcu_clock_freq_enum clock);
+
+GD32VF103_END_DECLS
 
 #endif /* GD32VF103_RCU_H */

--- a/SoC/gd32vf103/Common/Include/gd32vf103_rtc.h
+++ b/SoC/gd32vf103/Common/Include/gd32vf103_rtc.h
@@ -39,6 +39,8 @@ OF SUCH DAMAGE.
 #include "gd32vf103_rcu.h"
 #include "gd32vf103_dbg.h"
 
+GD32VF103_BEGIN_DECLS
+
 /* RTC definitions */
 #define RTC                          RTC_BASE
 
@@ -146,5 +148,7 @@ void rtc_interrupt_flag_clear(uint32_t flag);
 void rtc_interrupt_enable(uint32_t interrupt);
 /* disable RTC interrupt */
 void rtc_interrupt_disable(uint32_t interrupt);
+
+GD32VF103_END_DECLS
 
 #endif /* GD32VF103_RTC_H */

--- a/SoC/gd32vf103/Common/Include/gd32vf103_spi.h
+++ b/SoC/gd32vf103/Common/Include/gd32vf103_spi.h
@@ -39,6 +39,8 @@ OF SUCH DAMAGE.
 #include "gd32vf103_rcu.h"
 #include "gd32vf103_dbg.h"
 
+GD32VF103_BEGIN_DECLS
+
 /* SPIx(x=0,1,2) definitions */
 #define SPI0                            (SPI_BASE + 0x0000F800U)
 #define SPI1                            SPI_BASE
@@ -338,5 +340,7 @@ FlagStatus spi_i2s_interrupt_flag_get(uint32_t spi_periph, uint8_t interrupt);
 FlagStatus spi_i2s_flag_get(uint32_t spi_periph, uint32_t flag);
 /* clear SPI CRC error flag status */
 void spi_crc_error_clear(uint32_t spi_periph);
+
+GD32VF103_END_DECLS
 
 #endif /* GD32VF103_SPI_H */

--- a/SoC/gd32vf103/Common/Include/gd32vf103_timer.h
+++ b/SoC/gd32vf103/Common/Include/gd32vf103_timer.h
@@ -39,6 +39,8 @@ OF SUCH DAMAGE.
 #include "gd32vf103_rcu.h"
 #include "gd32vf103_dbg.h"
 
+GD32VF103_BEGIN_DECLS
+
 /* TIMERx(x=0..13) definitions */
 #define TIMER0                           (TIMER_BASE + 0x00012C00U)
 #define TIMER1                           (TIMER_BASE + 0x00000000U)
@@ -716,5 +718,7 @@ void timer_interrupt_flag_clear(uint32_t timer_periph, uint32_t interrupt);
 FlagStatus timer_flag_get(uint32_t timer_periph, uint32_t flag);
 /* clear TIMER flag */
 void timer_flag_clear(uint32_t timer_periph, uint32_t flag);
+
+GD32VF103_END_DECLS
 
 #endif /* GD32VF103_TIMER_H */

--- a/SoC/gd32vf103/Common/Include/gd32vf103_usart.h
+++ b/SoC/gd32vf103/Common/Include/gd32vf103_usart.h
@@ -39,6 +39,8 @@ OF SUCH DAMAGE.
 #include "gd32vf103_rcu.h"
 #include "gd32vf103_dbg.h"
 
+GD32VF103_BEGIN_DECLS
+
 /* USARTx(x=0,1,2)/UARTx(x=3,4) definitions */
 #define USART1                        USART_BASE                        /*!< USART1 base address */
 #define USART2                        (USART_BASE+(0x00000400U))        /*!< USART2 base address */
@@ -372,4 +374,6 @@ FlagStatus usart_interrupt_flag_get(uint32_t usart_periph, uint32_t int_flag);
 void usart_interrupt_flag_clear(uint32_t usart_periph, uint32_t flag);
 int usart_write(uint32_t usart_periph, int ch);
 uint8_t usart_read(uint32_t usart_periph);
+GD32VF103_END_DECLS
+
 #endif /* GD32VF103_USART_H */

--- a/SoC/gd32vf103/Common/Include/gd32vf103_wwdgt.h
+++ b/SoC/gd32vf103/Common/Include/gd32vf103_wwdgt.h
@@ -39,6 +39,8 @@ OF SUCH DAMAGE.
 #include "gd32vf103_rcu.h"
 #include "gd32vf103_dbg.h"
 
+GD32VF103_BEGIN_DECLS
+
 /* WWDGT definitions */
 #define WWDGT                       WWDGT_BASE                                /*!< WWDGT base address */
 
@@ -84,5 +86,7 @@ void wwdgt_interrupt_enable(void);
 FlagStatus wwdgt_flag_get(void);
 /* clear early wakeup interrupt state of WWDGT */
 void wwdgt_flag_clear(void);
+
+GD32VF103_END_DECLS
 
 #endif /* GD32VF103_WWDGT_H */


### PR DESCRIPTION
Motivation: Previously, one had to remember to always include SDK
headers from a C++ translation unit like this:

    extern "C" {
    #include <gd32vf103_rcu.h>
    #include <gd32vf103_gpio.h>
    }

Which arguably is a bit tedious and errorprone. And when leaving those
out it's perhaps not entirely obvious to beginners why they are getting
weird linker errors.

This commit thus wraps all the SDK API headers inside appropriate guards
using with the following macros

    GD32VF103_BEGIN_DECLS
    GD32VF103_END_DECLS

such that a C++ translation can include them simply via e.g.:

    #include <gd32vf103_rcu.h>
    #include <gd32vf103_gpio.h>

Note that this pattern follows what other libraries such as the Glibc,
Glib or GSL do with their headers.