### PR TITLE
Read RTC counter robustly

### DIFF
--- a/SoC/gd32vf103/Common/Source/Drivers/gd32vf103_rtc.c
+++ b/SoC/gd32vf103/Common/Source/Drivers/gd32vf103_rtc.c
@@ -147,11 +147,16 @@ void rtc_alarm_config(uint32_t alarm)
 */
 uint32_t rtc_counter_get(void)
 {
-    uint32_t temp = 0x0U;
-
-    temp = RTC_CNTL;
-    temp |= (RTC_CNTH << RTC_HIGH_BITS_OFFSET);
-    return temp;
+    uint32_t prev_h = RTC_CNTH;
+    for (;;) {
+        uint32_t temp = RTC_CNTL;
+        uint32_t h = RTC_CNTH;
+        if (h == prev_h) {
+            temp |= (h << RTC_HIGH_BITS_OFFSET);
+            return temp;
+        }
+        prev_h = h;
+    }
 }
 
 /*!


### PR DESCRIPTION
I noticed that when calling `rtc_counter_get()` several times in a row the returned values sometimes aren't monotonically increasing, even if the counter didn't overflow. 

The reason for it is:

Since the 32 bit RTC counter is split into two 16 bit halves RTC_CNTH
and RTC_CNTL, reading it is racy:

- when loading in order RTC_CNTL, RTC_CNTH: RTC_CNTL might overflow and thus
  yield an increment of RTC_CNTH just after RTC_CNTL is loaded and before
  RTC_CNTH is loaded
- when loading in order RTC_CNTH, RTC_CNTL: RTC_CNTH might increment
  just after it is loaded and before RTC_CNTL is loaded thus the
  following RTC_CNTL load contains the overflowed value

This change detects when the combined value would be bogus and retries to load
both halves.

---

Btw, I'm curious why most these peripheral registers have the upper 16 bits reserved, such that, as a consequence, fields larger than 16 bits must be split. Do you know the reasoning behind this design?