### PR TITLE
SoC/gd32vf103: Fix deep sleep behavior in pmu_to_deepsleepmode

### DIFF
--- a/SoC/gd32vf103/Common/Include/system_gd32vf103.h
+++ b/SoC/gd32vf103/Common/Include/system_gd32vf103.h
@@ -74,6 +74,11 @@ extern void SystemInit(void);
 extern void SystemCoreClockUpdate(void);
 
 /**
+ * \brief Configure the system clock
+ */
+extern void system_clock_config(void);
+
+/**
  * \brief Dump Exception Frame
  */
 void Exception_DumpFrame(unsigned long sp);

--- a/SoC/gd32vf103/Common/Source/Drivers/gd32vf103_pmu.c
+++ b/SoC/gd32vf103/Common/Source/Drivers/gd32vf103_pmu.c
@@ -112,6 +112,9 @@ void pmu_to_sleepmode(uint8_t sleepmodecmd)
 
 /*!
     \brief      PMU work at deepsleep mode
+
+    NB: Deep sleep mode sets the clock to IRC8M. Thus, you may need to restore
+        your original clock settings. For example, by calling system_clock_config().
     \param[in]  ldo:
                 only one parameter can be selected which is shown as below:
       \arg        PMU_LDO_NORMAL: LDO work at normal power mode when pmu enter deepsleep mode

--- a/SoC/gd32vf103/Common/Source/Drivers/gd32vf103_pmu.c
+++ b/SoC/gd32vf103/Common/Source/Drivers/gd32vf103_pmu.c
@@ -98,7 +98,7 @@ void pmu_lvd_disable(void)
 void pmu_to_sleepmode(uint8_t sleepmodecmd)
 {
     /* clear sleepdeep bit of RISC-V system control register */
-    __RV_CSR_CLEAR(CSR_WFE, WFE_WFE);
+    __set_wfi_sleepmode(WFI_SHALLOW_SLEEP);
 
     /* select WFI or WFE command to enter sleep mode */
     if (WFI_CMD == sleepmodecmd) {
@@ -130,7 +130,7 @@ void pmu_to_deepsleepmode(uint32_t ldo, uint8_t deepsleepmodecmd)
     /* set ldolp bit according to pmu_ldo */
     PMU_CTL |= ldo;
     /* set CSR_SLEEPVALUE bit of RISC-V system control register */
-    __RV_CSR_SET(CSR_WFE, WFE_WFE);
+    __set_wfi_sleepmode(WFI_DEEP_SLEEP);
     /* select WFI or WFE command to enter deepsleep mode */
     if (WFI_CMD == deepsleepmodecmd) {
         __WFI();
@@ -140,7 +140,7 @@ void pmu_to_deepsleepmode(uint32_t ldo, uint8_t deepsleepmodecmd)
         __enable_irq();
     }
     /* reset sleepdeep bit of RISC-V system control register */
-    __RV_CSR_CLEAR(CSR_WFE, WFE_WFE);
+    __set_wfi_sleepmode(WFI_SHALLOW_SLEEP);
 }
 
 /*!
@@ -155,7 +155,7 @@ void pmu_to_deepsleepmode(uint32_t ldo, uint8_t deepsleepmodecmd)
 void pmu_to_standbymode(uint8_t standbymodecmd)
 {
     /* set CSR_SLEEPVALUE bit of RISC-V system control register */
-    __RV_CSR_SET(CSR_WFE, WFE_WFE);
+    __set_wfi_sleepmode(WFI_DEEP_SLEEP);
 
     /* set stbmod bit */
     PMU_CTL |= PMU_CTL_STBMOD;
@@ -166,12 +166,12 @@ void pmu_to_standbymode(uint8_t standbymodecmd)
     /* select WFI or WFE command to enter standby mode */
     if (WFI_CMD == standbymodecmd) {
         __WFI();
+        // system resets on wakeup
     } else {
         __disable_irq();
         __WFE();
-        __enable_irq();
+        // system resets on wakeup
     }
-    __RV_CSR_CLEAR(CSR_WFE, WFE_WFE);
 }
 
 /*!

--- a/SoC/gd32vf103/Common/Source/system_gd32vf103.c
+++ b/SoC/gd32vf103/Common/Source/system_gd32vf103.c
@@ -185,7 +185,7 @@ static void system_clock_108m_hxtal(void)
     \param[out] none
     \retval     none
 */
-static void system_clock_config(void)
+void system_clock_config(void)
 {
     system_clock_108m_hxtal();
 }


### PR DESCRIPTION
While trying to make the MCU enter deep sleep mode I noticed that `pmu_to_deepsleepmode()` doesn't work, i.e. that deep sleep mode isn't entered.

I thus reviewed the code and noticed that the custom SLEEPVALUE RISC-V control and status register (CSR) isn't set as described in the GD32VF103 manual.

This change fixes this function and while at it I reviewed and fixed the other sleep/standby functions, as well.

---

As mentioned by the manual, when the MCU enters deep sleep mode the system clock is reset to IRC8M - and stays that way when it wakes up again. Thus, with the default system initialization (which sets the system clock to PLL 108 MHz) it's imperative to explicitly reconfigure the system clock to the old state.

Otherwise, peripherals like USART don't work anymore after leaving deep sleep.

In order to simplify this common use case I also changed the visibility of `system_clock_config()` from static to global such that user code can simply call it after `pmu_to_deepsleepmode()`.

---

Ideally, `pmu_to_deepsleepmode()` would save the current clock configuration before entering deep sleep mode and if (and only if  the old clock configuration wasn't already IRC8M) restore all the bits and pieces. However, this takes more effort to implement and perhaps is a little bit tricky to support all possible configurations.

---

I thought about changing `system_clock_config()` to weak linkage, i.e. to allow users to provide their own system clock initialization function in case they want to clock the MCU differently (e.g. just 8 MHz to save power).

I'm not sure, perhaps there is a better way for such customization.