### PR TITLE
fix: fix "usb_conf.h" not found

### DIFF
--- a/SoC/gd32vf103/Common/Include/Usb/usb_conf.h
+++ b/SoC/gd32vf103/Common/Include/Usb/usb_conf.h
@@ -1,0 +1,101 @@
+#ifndef __USB_CONF_H
+#define __USB_CONF_H
+
+#include <stddef.h>
+#include "gd32vf103.h"
+
+//#ifndef USE_USB_FS
+//#define USE_USB_HS
+//#endif
+
+#define USE_USB_FS
+
+#ifdef USE_USB_FS
+#define USB_FS_CORE
+#endif
+
+#ifdef USE_USB_HS
+#define USB_HS_CORE
+#endif
+
+#ifdef USB_FS_CORE
+#define RX_FIFO_FS_SIZE                         128
+#define TX0_FIFO_FS_SIZE                        64
+#define TX1_FIFO_FS_SIZE                        128
+#define TX2_FIFO_FS_SIZE                        0
+#define TX3_FIFO_FS_SIZE                        0
+#define USB_RX_FIFO_FS_SIZE                     128
+#define USB_HTX_NPFIFO_FS_SIZE                  96
+#define USB_HTX_PFIFO_FS_SIZE                   96
+#endif /* USB_FS_CORE */
+
+#ifdef USB_HS_CORE
+#define RX_FIFO_HS_SIZE                          512
+#define TX0_FIFO_HS_SIZE                         128
+#define TX1_FIFO_HS_SIZE                         372
+#define TX2_FIFO_HS_SIZE                         0
+#define TX3_FIFO_HS_SIZE                         0
+#define TX4_FIFO_HS_SIZE                         0
+#define TX5_FIFO_HS_SIZE                         0
+
+#ifdef USE_ULPI_PHY
+#define USB_OTG_ULPI_PHY_ENABLED
+#endif
+
+#ifdef USE_EMBEDDED_PHY
+#define USB_OTG_EMBEDDED_PHY_ENABLED
+#endif
+
+#define USB_OTG_HS_INTERNAL_DMA_ENABLED
+#define USB_OTG_HS_DEDICATED_EP1_ENABLED
+#endif /* USB_HS_CORE */
+
+#ifndef USB_SOF_OUTPUT
+#define USB_SOF_OUTPUT                                     0
+#endif
+
+#ifndef USB_LOW_POWER
+#define USB_LOW_POWER                                      0
+#endif
+
+//#define USE_HOST_MODE
+//#define USE_DEVICE_MODE
+//#define USE_OTG_MODE
+
+#ifndef USE_HOST_MODE
+#define  USE_DEVICE_MODE
+#endif
+
+#ifndef USB_FS_CORE
+#ifndef USB_HS_CORE
+#error "USB_HS_CORE or USB_FS_CORE should be defined"
+#endif
+#endif
+
+#ifndef USE_DEVICE_MODE
+#ifndef USE_HOST_MODE
+#error "USE_DEVICE_MODE or USE_HOST_MODE should be defined"
+#endif
+#endif
+
+#ifndef USE_USB_HS
+#ifndef USE_USB_FS
+#error "USE_USB_HS or USE_USB_FS should be defined"
+#endif
+#endif
+
+/****************** C Compilers dependant keywords ****************************/
+/* In HS mode and when the DMA is used, all variables and data structures dealing
+   with the DMA during the transaction process should be 4-bytes aligned */
+#ifdef USB_OTG_HS_INTERNAL_DMA_ENABLED
+#if defined   (__GNUC__)            /* GNU Compiler */
+#define __ALIGN_END __attribute__ ((aligned(4)))
+#define __ALIGN_BEGIN
+#endif                              /* __GNUC__ */
+#else
+#define __ALIGN_BEGIN
+#define __ALIGN_END
+#endif /* USB_OTG_HS_INTERNAL_DMA_ENABLED */
+
+#endif /* __USB_CONF_H */
+

--- a/SoC/gd32vf103/Common/Include/Usb/usbd_conf.h
+++ b/SoC/gd32vf103/Common/Include/Usb/usbd_conf.h
@@ -1,0 +1,10 @@
+#ifndef __USBD_CONF_H
+#define __USBD_CONF_H
+
+#include "usb_conf.h"
+
+#define USBD_CFG_MAX_NUM                    1
+#define USBD_ITF_MAX_NUM                    1
+
+#endif /* __USBD_CONF_H */
+

--- a/SoC/gd32vf103/Common/Include/Usb/usbh_conf.h
+++ b/SoC/gd32vf103/Common/Include/Usb/usbh_conf.h
@@ -1,0 +1,9 @@
+#ifndef __USBH_CONF_H
+#define __USBH_CONF_H
+
+#define USBH_MAX_EP_NUM                         2
+#define USBH_MAX_INTERFACES_NUM                 2
+#define USBH_MSC_MPS_SIZE                       0x200
+
+#endif /* __USBH_CONF_H */
+


### PR DESCRIPTION
I found that these three files has been remove at 0.3.8, but still using now. So I just copy them back.