### PR TITLE
build: fix bugs in "upload" target, remove useless semicolons.

### DIFF
--- a/Build/Makefile.conf
+++ b/Build/Makefile.conf
@@ -56,7 +56,7 @@ GDB_PORT ?= 3333
 ## in remote machine(ipaddr 192.168.43.199, port 3333) which connect the hardware board,
 ## then you can change the GDBREMOTE to 192.168.43.199:3333
 ## GDBREMOTE ?= 192.168.43.199:3333
-GDBREMOTE ?= | $(OPENOCD) $(OPENOCD_OPT) -c \"$(OPENOCD_CMD_ARGS); gdb_port pipe; log_output openocd.log\" -f $(OPENOCD_CFG)
+GDBREMOTE ?= | $(OPENOCD) $(OPENOCD_OPT) -c \"$(OPENOCD_CMD_ARGS) gdb_port pipe; log_output openocd.log\" -f $(OPENOCD_CFG)
 
 GDB_UPLOAD_ARGS ?= --batch
 GDB_UPLOAD_CMDS += -ex 'thread apply all monitor reset halt'
@@ -78,7 +78,7 @@ GDB_UPLOAD_CMDS += -ex 'thread 1'
 GDB_UPLOAD_CMDS += -ex 'monitor resume'
 GDB_UPLOAD_CMDS += -ex 'quit'
 
-OPENOCD_PORT_ARGS = -c "$(OPENOCD_CMD_ARGS); gdb_port $(GDB_PORT)"
+OPENOCD_PORT_ARGS = -c "$(OPENOCD_CMD_ARGS) gdb_port $(GDB_PORT)"
 
 OPENOCD_ARGS += $(OPENOCD_OPT) -f $(OPENOCD_CFG)
 GDB_CMDS += -ex "set remotetimeout 240"

--- a/Build/Makefile.rules
+++ b/Build/Makefile.rules
@@ -122,7 +122,7 @@ size: $(TARGET_ELF)
 
 upload: $(TARGET_ELF)
 	@$(ECHO) "Download and run $<"
-	$(GDB) -ex "set remotetimeout 240" \
+	$(GDB) $< -ex "set remotetimeout 240" \
 	-ex "target remote $(GDBREMOTE)" \
 	$(GDB_UPLOAD_ARGS) $(GDB_UPLOAD_CMDS)
 


### PR DESCRIPTION
1) I found that there are extra semicolons in the "GDBREMOTE" and "OPENOCD_PORT_ARGS" variables of Makefile.conf, since the "OPENOCD_CMD_ARGS" is empty, an useless semicolon will be leaved.

2) $< is missing in the upload target of Makefile.rules

I have tested these changes in gd32vf103_rv_star board.