### PR TITLE
[zcc] Update some compiler options for zcc-4.0.0

### DIFF
--- a/application/baremetal/benchmark/coremark/npk.yml
+++ b/application/baremetal/benchmark/coremark/npk.yml
@@ -102,7 +102,7 @@ buildconfig:
       - flags: -O3 -flto
   - type: zcc
     common_flags: # flags need to be combined together across all packages
-      - flags: -O3 -flto -falign-functions=4 -falign-loops=4 -flate-loop-unroll -malign-branch
+      - flags: -O3 -flto -falign-functions=4 -falign-loops=4 -flate-loop-unroll -malign-branch -fuse-size-lib
     ldflags:
       - flags: -Wl,-mllvm,--align-all-nofallthru-blocks=2
 

--- a/application/baremetal/benchmark/coremark/toolchain_terapines.mk
+++ b/application/baremetal/benchmark/coremark/toolchain_terapines.mk
@@ -1,2 +1,2 @@
-BENCH_FLAGS ?= -O3 -flto -falign-functions=4 -falign-loops=4 -flate-loop-unroll -malign-branch
+BENCH_FLAGS ?= -O3 -flto -falign-functions=4 -falign-loops=4 -flate-loop-unroll -malign-branch -fuse-size-lib
 LDFLAGS += -Wl,-mllvm,--align-all-nofallthru-blocks=2

--- a/application/baremetal/benchmark/dhrystone/npk.yml
+++ b/application/baremetal/benchmark/dhrystone/npk.yml
@@ -88,7 +88,7 @@ buildconfig:
 
         condition: $( ${dhry_mode} == 'ground' )
       - flags: >-
-              -O3 -ffast-math -flto -finline -fno-builtin-printf -funroll-loops -falign-functions=4 -falign-loops=4 -finline-functions -flate-loop-unroll -malign-branch
+              -O3 -ffast-math -flto -finline -fno-builtin-printf -funroll-loops -falign-functions=4 -falign-loops=4 -finline-functions -flate-loop-unroll -malign-branch -fuse-size-lib
 
         condition: $( ${dhry_mode} == 'inline' )
       - flags: >-

--- a/application/baremetal/benchmark/dhrystone/toolchain_terapines.mk
+++ b/application/baremetal/benchmark/dhrystone/toolchain_terapines.mk
@@ -1,5 +1,5 @@
 ifeq ($(DHRY_MODE),ground)
-BENCH_FLAGS ?= -O3 -ffast-math -flto -fno-inline -fno-builtin-printf -funroll-loops -falign-functions=4 -falign-loops=4 -flate-loop-unroll -malign-branch
+BENCH_FLAGS ?= -O3 -ffast-math -flto -fno-inline -fno-builtin-printf -funroll-loops -falign-functions=4 -falign-loops=4 -flate-loop-unroll -malign-branch -fuse-size-lib
 LDFLAGS += -Wl,-mllvm,--align-all-nofallthru-blocks=2
 else ifeq ($(DHRY_MODE),best)
 BENCH_FLAGS ?= -O3 -ffast-math -flto -finline -fno-builtin-printf -funroll-loops -falign-functions=4 -falign-loops=4 -finline-functions -flate-loop-unroll -malign-branch


### PR DESCRIPTION
Update new optimization options for zcc 4.0.0. It can reduce some code-size of coremark and dhrystone.

after this,

|                     | n300  | n310  | u900  |
| ------------------- | ----- | ----- | ----- |
| coremark score      | 3.959 | 4.52  | 5.865 |
| coremark code-size  | 34620 | 34652 | 34756 |
| dhrystone score     | 1.929 | 2.223 | 2.995 |
| dhrystone code-size | 15672 | 15672 | 15664 |