### PR TITLE
[zcc] Remove the -fuse-size-lib compile flag

### DIFF
--- a/application/baremetal/benchmark/coremark/npk.yml
+++ b/application/baremetal/benchmark/coremark/npk.yml
@@ -104,5 +104,5 @@ buildconfig:
     common_flags: # flags need to be combined together across all packages
       - flags: -O3 -flto -falign-functions=4 -falign-loops=4 -flate-loop-unroll -malign-branch
     ldflags:
-      - flags: -Wl,-mllvm,--align-all-nofallthru-blocks=2 -fuse-size-lib
+      - flags: -Wl,-mllvm,--align-all-nofallthru-blocks=2
 

--- a/application/baremetal/benchmark/coremark/toolchain_terapines.mk
+++ b/application/baremetal/benchmark/coremark/toolchain_terapines.mk
@@ -1,2 +1,2 @@
 BENCH_FLAGS ?= -O3 -flto -falign-functions=4 -falign-loops=4 -flate-loop-unroll -malign-branch
-LDFLAGS += -Wl,-mllvm,--align-all-nofallthru-blocks=2 -fuse-size-lib
+LDFLAGS += -Wl,-mllvm,--align-all-nofallthru-blocks=2

--- a/application/baremetal/benchmark/dhrystone/npk.yml
+++ b/application/baremetal/benchmark/dhrystone/npk.yml
@@ -96,4 +96,4 @@ buildconfig:
 
         condition: $( ${dhry_mode} == 'best' )
     ldflags:
-      - flags: -Wl,-mllvm,--align-all-nofallthru-blocks=2 -fuse-size-lib
+      - flags: -Wl,-mllvm,--align-all-nofallthru-blocks=2

--- a/application/baremetal/benchmark/dhrystone/toolchain_terapines.mk
+++ b/application/baremetal/benchmark/dhrystone/toolchain_terapines.mk
@@ -5,4 +5,4 @@ BENCH_FLAGS ?= -O3 -ffast-math -flto -finline -fno-builtin-printf -funroll-loops
 else ifeq ($(DHRY_MODE),inline)
 BENCH_FLAGS ?= -O3 -flto -finline -fno-builtin-printf -funroll-loops -falign-functions=4 -falign-loops=4 -finline-functions -flate-loop-unroll -malign-branch
 endif
-LDFLAGS += -Wl,-mllvm,--align-all-nofallthru-blocks=2 -fuse-size-lib
+LDFLAGS += -Wl,-mllvm,--align-all-nofallthru-blocks=2

--- a/application/baremetal/benchmark/dhrystone_v2.2/npk.yml
+++ b/application/baremetal/benchmark/dhrystone_v2.2/npk.yml
@@ -45,4 +45,4 @@ buildconfig:
     common_flags: # flags need to be combined together across all packages
       - flags: -O3 -Wno-implicit-int -Wno-implicit-function-declaration
     ldflags:
-      - flags: -Wl,-mllvm,--align-all-nofallthru-blocks=2 -fuse-size-lib
+      - flags: -Wl,-mllvm,--align-all-nofallthru-blocks=2

--- a/application/baremetal/benchmark/dhrystone_v2.2/toolchain_terapines.mk
+++ b/application/baremetal/benchmark/dhrystone_v2.2/toolchain_terapines.mk
@@ -1,2 +1,2 @@
 BENCH_FLAGS ?= -O3
-LDFLAGS += -Wl,-mllvm,--align-all-nofallthru-blocks=2 -fuse-size-lib
+LDFLAGS += -Wl,-mllvm,--align-all-nofallthru-blocks=2


### PR DESCRIPTION
This option is no longer effective in zcc version 4.1.2 and later.
This option searches for C libraries under the size directory and is now being deprecated.